### PR TITLE
feat(ui): migrate dashboard index page

### DIFF
--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -24,9 +24,9 @@
 - [ ] Validate logout redirect path.
 
 ### 2) Dashboard (`static/index.html`)
-- [ ] Build dashboard service-card grid with reusable card component.
-- [ ] Preserve service icon mapping behavior.
-- [ ] Preserve launch/open actions.
+- [x] Build dashboard service-card grid with reusable card component.
+- [x] Preserve service icon mapping behavior.
+- [x] Preserve launch/open actions.
 
 ### 3) System (`static/system.html`)
 - [ ] Build metric cards with shared `MetricCard` component.

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -1,0 +1,167 @@
+.ph-home {
+    min-height: 100vh;
+    background:
+        radial-gradient(1200px 680px at -8% -18%, rgba(14, 165, 233, 0.18), transparent 62%),
+        radial-gradient(900px 580px at 108% -24%, rgba(251, 146, 60, 0.18), transparent 62%),
+        linear-gradient(180deg, #f6fbff 0%, #ebf4fb 100%);
+}
+
+.ph-home-hero {
+    max-width: 1160px;
+    margin: 22px auto 8px;
+    padding: 18px 20px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.72);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 20px 44px rgba(15, 23, 42, 0.12);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.ph-home-kicker {
+    margin: 0;
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+}
+
+.ph-home-title {
+    margin: 4px 0 0;
+    font-size: clamp(1.2rem, 1.9vw, 1.6rem);
+    letter-spacing: -0.02em;
+}
+
+.ph-home-subtitle {
+    margin: 6px 0 0;
+    color: #64748b;
+    font-size: 0.92rem;
+}
+
+.ph-home-meta {
+    color: #475569;
+    font-size: 0.86rem;
+    font-family: var(--font-mono);
+}
+
+.ph-services {
+    max-width: 1160px;
+    margin: 0 auto;
+    padding: 10px 20px 28px;
+}
+
+.ph-service-grid {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+.ph-state {
+    border-radius: 20px;
+    border: 1px dashed rgba(15, 23, 42, 0.22);
+    background: rgba(255, 255, 255, 0.65);
+    min-height: 210px;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    color: #475569;
+    padding: 16px;
+}
+
+.ph-state[data-tone='error'] {
+    border-color: rgba(185, 28, 28, 0.32);
+    color: #991b1b;
+}
+
+.ph-service-card {
+    border-radius: 22px;
+    overflow: hidden;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 16px 34px rgba(15, 23, 42, 0.12);
+    transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.ph-service-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 22px 42px rgba(15, 23, 42, 0.17);
+    border-color: rgba(15, 118, 110, 0.35);
+}
+
+.ph-service-banner {
+    min-height: 102px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #f8fafc;
+}
+
+.ph-service-banner svg {
+    width: 42px;
+    height: 42px;
+}
+
+.ph-service-content {
+    padding: 16px 16px 18px;
+    text-align: center;
+}
+
+.ph-service-title {
+    margin: 0;
+    font-size: 1.08rem;
+    letter-spacing: -0.01em;
+}
+
+.ph-service-port {
+    margin: 8px 0 14px;
+    font-size: 0.84rem;
+    color: #64748b;
+    font-family: var(--font-mono);
+}
+
+.ph-service-link {
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 13px;
+    padding: 10px 14px;
+    background: linear-gradient(135deg, #0f766e, #0b8a80);
+    color: #f0fdfa;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    box-shadow: 0 12px 24px rgba(15, 118, 110, 0.24);
+}
+
+.ph-service-link:hover {
+    filter: brightness(1.03);
+}
+
+.ph-action-link {
+    margin-top: 12px;
+    display: inline-flex;
+    border-radius: 12px;
+    padding: 9px 14px;
+    border: 1px solid rgba(15, 23, 42, 0.18);
+    color: #0f172a;
+    text-decoration: none;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.92);
+}
+
+@media (max-width: 720px) {
+    .ph-home-hero {
+        margin-top: 12px;
+        padding: 14px 15px;
+        border-radius: 18px;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .ph-services {
+        padding: 8px 15px 20px;
+    }
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,300 +1,34 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        // Redirect to login if not logged in
-        if (!sessionStorage.getItem("loggedIn")) {
-            window.location.href = "/login.html";
-        }
-
-        // Display logged-in user
-        const username = sessionStorage.getItem("username");
-        if (username) {
-            document.addEventListener('DOMContentLoaded', () => {
-                const userEl = document.getElementById('logged-in-user');
-                if (userEl) userEl.textContent = username;
-            });
-        }
-
-        // Logout function
-        async function logout() {
-            try {
-                await fetch('/api/logout', { method: 'POST' });
-            } catch (e) {
-                // Ignore errors
-            }
-            sessionStorage.clear();
-            window.location.href = '/login.html';
-        }
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pi-Health Dashboard</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="stylesheet" href="/css/foundation.css">
+    <link rel="stylesheet" href="/css/index.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
-    <style>
-        .status-running { background-color: #38a169; }
-        .status-stopped { background-color: #e53e3e; }
-        .status-other { background-color: #dd6b20; }
-        .button:active { transform: scale(0.95); }
-        
-        /* Animation for actions */
-        .animate-pulse {
-            animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        }
-        
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
-        }
-        
-        /* Card hover effect */
-        .service-card {
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-            border: 2px solid rgba(95, 75, 139, 0.3);
-        }
-        
-        .service-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 10px 15px -3px rgba(138, 43, 226, 0.4);
-            border: 2px solid rgba(138, 43, 226, 0.6);
-        }
-        
-        /* Custom Coraline button */
-        .coraline-button {
-            background: linear-gradient(to bottom, #5f4b8b, #372b53);
-            border: 1px solid #8a6cbd;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
-            transition: all 0.3s ease;
-        }
-        
-        .coraline-button:hover {
-            background: linear-gradient(to bottom, #6f58a3, #413162);
-            transform: translateY(-2px);
-            box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
-        }
-    </style>
 </head>
-<body class="bg-gray-900 text-blue-100 font-sans min-h-screen">
-    <header class="bg-gradient-to-r from-purple-900 to-blue-900 shadow-lg relative overflow-hidden">
-        <div class="absolute inset-0 overflow-hidden">
-            <img src="/theme-banner" alt="Dashboard" class="w-full h-full object-cover opacity-40 blur-sm" style="filter: hue-rotate(-10deg) saturate(1.15);">
+<body class="ph-home">
+    <header class="ph-home-hero">
+        <div>
+            <p class="ph-home-kicker">Service Overview</p>
+            <h1 class="ph-home-title">Docker Web Services</h1>
+            <p class="ph-home-subtitle">One-click access to running service UIs detected from your active containers.</p>
         </div>
-        <div class="container mx-auto px-8 py-12 relative">
-        </div>
+        <div class="ph-home-meta">last refresh: <span id="refresh-time">--:--:--</span></div>
     </header>
 
-    <!-- Navigation bar -->
-    <nav id="main-nav" class="bg-purple-900 shadow-md"></nav>
+    <nav id="main-nav" class="bg-slate-900/90 shadow-md"></nav>
 
-    <!-- Main content -->
-    <main class="container mx-auto p-6">
-        <h2 class="text-2xl font-semibold mb-6 text-center">Docker Web Services</h2>
-        
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6" id="service-grid">
-            <!-- Service cards will be loaded here -->
-            <div class="col-span-full text-center py-10">
-                <div class="inline-block animate-pulse">
-                    <svg class="w-10 h-10 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-                    </svg>
-                </div>
-                <p class="mt-2 text-xl">Loading services...</p>
-            </div>
-        </div>
+    <main class="ph-services">
+        <div class="ph-home-subtitle" aria-live="polite">running services: <strong id="service-count">0</strong></div>
+        <section class="ph-service-grid" id="service-grid" aria-label="Docker web services"></section>
     </main>
 
-    <script>
-        // Optional overrides for icons and friendly names
-        const serviceOverrides = {
-            transmission: { icon: "transfer", name: "Transmission" },
-            jackett: { icon: "search", name: "Jackett" },
-            sonarr: { icon: "tv", name: "Sonarr" },
-            radarr: { icon: "film", name: "Radarr" },
-            nzbget: { icon: "download", name: "NZBGet" },
-            jellyfin: { icon: "collection", name: "Jellyfin" },
-            get_iplayer: { icon: "play", name: "Get iPlayer" },
-            rtdclient: { icon: "cloud-download", name: "RTD Client" },
-            'airsonic-advanced': { icon: "music", name: "Airsonic" },
-            rdtclient: { icon: "cloud-download", name: "RDT Client" },
-            lidarr: { icon: "music", name: "Lidarr" },
-            audiobookshelf: { icon: "book", name: "Audiobookshelf" },
-        };
-
-        // Get icon for container - uses theme-specific icons if loaded
-        function getIcon(containerName) {
-            // Use theme-specific icons if available
-            const iconSVGs = window.ThemeIcons || getDefaultIcons();
-
-            const service = serviceOverrides[containerName];
-            if (service && service.icon && iconSVGs[service.icon]) {
-                return iconSVGs[service.icon];
-            }
-            return iconSVGs.default;
-        }
-
-        // Default fallback icons (simple, neutral design)
-        function getDefaultIcons() {
-            return {
-                transfer: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><path d="M8 15V9m0 0L5 12m3-3l3 3m5-3v6m0 0l3-3m-3 3l-3-3" stroke="#9ca3af" stroke-width="2" stroke-linecap="round"/></svg>',
-                search: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><circle cx="10.5" cy="10.5" r="3" stroke="#9ca3af" stroke-width="2"/><path d="M12.5 12.5l4 4" stroke="#9ca3af" stroke-width="2" stroke-linecap="round"/></svg>',
-                tv: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><rect x="7" y="8" width="10" height="6" rx="1" stroke="#9ca3af" stroke-width="1.5"/></svg>',
-                film: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><rect x="7" y="7" width="10" height="10" rx="1" stroke="#9ca3af" stroke-width="1.5"/></svg>',
-                download: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><path d="M12 7v8m0 0l-3-3m3 3l3-3" stroke="#9ca3af" stroke-width="2" stroke-linecap="round"/></svg>',
-                collection: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><rect x="7" y="8" width="10" height="3" rx="0.5" stroke="#9ca3af" stroke-width="1.5"/><rect x="7" y="13" width="10" height="3" rx="0.5" stroke="#9ca3af" stroke-width="1.5"/></svg>',
-                play: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><path d="M10 8l6 4-6 4V8z" fill="#9ca3af"/></svg>',
-                'cloud-download': '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><path d="M8 11a3 3 0 016 0h2c1 0 2 1 2 2s-1 2-2 2H8c-1 0-2-1-2-2s1-2 2-2z" stroke="#9ca3af" stroke-width="1.5"/></svg>',
-                music: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><path d="M9 15V9l6-2v8" stroke="#9ca3af" stroke-width="1.5" stroke-linecap="round"/></svg>',
-                book: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><path d="M12 8v8M12 8c-1-1-2-1-3-1M12 8c1-1 2-1 3-1" stroke="#9ca3af" stroke-width="1.5" stroke-linecap="round"/></svg>',
-                default: '<svg class="w-10 h-10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="#6b7280" stroke-width="2" fill="#374151"/><rect x="7" y="10" width="10" height="4" rx="0.5" stroke="#9ca3af" stroke-width="1.5"/></svg>'
-            };
-        }
-
-        // Get friendly name for container
-        function getFriendlyName(containerName) {
-            const service = serviceOverrides[containerName];
-            if (service && service.name) {
-                return service.name;
-            }
-            // Convert container_name or container-name to Title Case
-            return containerName
-                .replace(/[-_]/g, ' ')
-                .replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase())));
-        }
-
-        // Get background color gradient based on container name
-        function getBackgroundGradient(containerName) {
-            // Use theme gradients (loaded dynamically from theme.js)
-            const gradients = window.ThemeLoader ? window.ThemeLoader.getThemeGradients() : [
-                'from-purple-800 to-indigo-900',
-                'from-indigo-800 to-purple-900',
-                'from-blue-800 to-purple-900',
-                'from-purple-900 to-blue-800',
-                'from-indigo-900 to-blue-900',
-                'from-blue-900 to-indigo-900'
-            ];
-
-            // Generate a pseudorandom but consistent color based on the container name
-            let hash = 0;
-            for (let i = 0; i < containerName.length; i++) {
-                hash = containerName.charCodeAt(i) + ((hash << 5) - hash);
-            }
-
-            return gradients[Math.abs(hash) % gradients.length];
-        }
-
-        function getWebUIPort(container) {
-            if (!container.ports || container.ports.length === 0) {
-                return null;
-            }
-
-            const tcpPorts = container.ports.filter(port => port.protocol !== 'udp');
-
-            const hostTcp = tcpPorts.find(port => port.host_port);
-            if (hostTcp) {
-                return hostTcp.host_port;
-            }
-
-            const anyHost = container.ports.find(port => port.host_port);
-            if (anyHost) {
-                return anyHost.host_port;
-            }
-
-            const tcpContainer = tcpPorts.find(port => port.container_port);
-            if (tcpContainer) {
-                return tcpContainer.container_port;
-            }
-
-            const fallback = container.ports.find(port => port.container_port);
-            return fallback ? fallback.container_port : null;
-        }
-
-        // Fetch Docker containers and create service cards
-        async function fetchDockerWebServices() {
-            const serviceGrid = document.getElementById('service-grid');
-
-            try {
-                const response = await apiFetch('/api/containers?stats=false');
-                const containers = await response.json();
-
-                // Handle error responses
-                if (!Array.isArray(containers)) {
-                    throw new Error(containers.error || 'Invalid response');
-                }
-
-                // Clear loading message
-                serviceGrid.innerHTML = '';
-
-                // Filter to only running containers with web UIs
-                const webServices = containers.filter(container =>
-                    container.status === 'running' &&
-                    getWebUIPort(container)
-                );
-                
-                if (webServices.length === 0) {
-                    serviceGrid.innerHTML = `
-                        <div class="col-span-full text-center py-10">
-                            <svg class="w-16 h-12 mx-auto text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                            </svg>
-                            <p class="mt-4 text-xl">No running web services found</p>
-                            <a href="/containers.html" class="mt-4 inline-block coraline-button text-blue-100 font-bold py-2 px-4 rounded-lg">
-                                Manage Containers
-                            </a>
-                        </div>
-                    `;
-                    return;
-                }
-                
-                // Create a card for each web service
-                webServices.forEach(container => {
-                    const port = getWebUIPort(container);
-                    const icon = getIcon(container.name);
-                    const friendlyName = getFriendlyName(container.name);
-                    const gradient = getBackgroundGradient(container.name);
-                    
-                    const card = document.createElement('div');
-                    card.className = `service-card bg-gray-800 rounded-lg shadow-lg overflow-hidden`;
-                    card.innerHTML = `
-                        <div class="bg-gradient-to-br ${gradient} p-6 flex justify-center">
-                            <div class="text-white">
-                                ${icon}
-                            </div>
-                        </div>
-                        <div class="p-4 text-center">
-                            <h3 class="text-xl font-semibold mb-2">${friendlyName}</h3>
-                            <a href="http://${window.location.hostname}:${port}" target="_blank" 
-                               class="inline-block coraline-button text-blue-100 font-bold py-2 px-4 rounded-lg transition duration-200">
-                                Open Service
-                            </a>
-                        </div>
-                    `;
-                    
-                    serviceGrid.appendChild(card);
-                });
-                
-            } catch (error) {
-                console.error('Error fetching Docker services:', error);
-                serviceGrid.innerHTML = `
-                    <div class="col-span-full text-center py-10">
-                        <svg class="w-16 h-12 mx-auto text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                        </svg>
-                        <p class="mt-4 text-xl">Error loading services</p>
-                        <p class="text-gray-400">${error.message}</p>
-                    </div>
-                `;
-            }
-        }
-        
-        // Initial fetch
-        fetchDockerWebServices();
-        
-        // Refresh every 30 seconds
-        setInterval(fetchDockerWebServices, 30000);
-    </script>
+    <script type="module" src="/js/pages/index.js"></script>
 </body>
 </html>

--- a/static/js/lib/auth.js
+++ b/static/js/lib/auth.js
@@ -1,0 +1,33 @@
+import { requestJson } from '/js/lib/http.js';
+import { clearClientSession, saveClientSession } from '/js/lib/session.js';
+
+export async function ensureAuthenticated({ redirectTo = '/login.html' } = {}) {
+    const localFlag = sessionStorage.getItem('loggedIn');
+    if (!localFlag) {
+        window.location.href = redirectTo;
+        return false;
+    }
+
+    const { response, payload } = await requestJson('/api/auth/check');
+    if (!response.ok || !payload?.authenticated) {
+        clearClientSession();
+        window.location.href = redirectTo;
+        return false;
+    }
+
+    if (payload?.username) {
+        saveClientSession(payload.username);
+    }
+    return true;
+}
+
+export async function logoutToLogin({ redirectTo = '/login.html' } = {}) {
+    try {
+        await fetch('/api/logout', { method: 'POST' });
+    } catch (_error) {
+        // Ignore logout transport errors and clear session client-side.
+    }
+
+    clearClientSession();
+    window.location.href = redirectTo;
+}

--- a/static/js/pages/index.js
+++ b/static/js/pages/index.js
@@ -1,0 +1,173 @@
+import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+
+const serviceGrid = document.getElementById('service-grid');
+const serviceCount = document.getElementById('service-count');
+const refreshTime = document.getElementById('refresh-time');
+
+const serviceOverrides = {
+    transmission: { icon: 'transfer', name: 'Transmission' },
+    jackett: { icon: 'search', name: 'Jackett' },
+    sonarr: { icon: 'tv', name: 'Sonarr' },
+    radarr: { icon: 'film', name: 'Radarr' },
+    nzbget: { icon: 'download', name: 'NZBGet' },
+    jellyfin: { icon: 'collection', name: 'Jellyfin' },
+    get_iplayer: { icon: 'play', name: 'Get iPlayer' },
+    rtdclient: { icon: 'cloud-download', name: 'RTD Client' },
+    'airsonic-advanced': { icon: 'music', name: 'Airsonic' },
+    rdtclient: { icon: 'cloud-download', name: 'RDT Client' },
+    lidarr: { icon: 'music', name: 'Lidarr' },
+    audiobookshelf: { icon: 'book', name: 'Audiobookshelf' },
+};
+
+function formatRefreshTime(date) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function renderState(message, tone = 'info', extraAction = '') {
+    serviceGrid.innerHTML = `
+        <section class="ph-state" data-tone="${tone}">
+            <div>
+                <p>${message}</p>
+                ${extraAction}
+            </div>
+        </section>
+    `;
+}
+
+function getDefaultIcons() {
+    return {
+        transfer: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><path d="M8 15V9m0 0L5 12m3-3l3 3m5-3v6m0 0l3-3m-3 3l-3-3" stroke="#f8fafc" stroke-width="2" stroke-linecap="round"/></svg>',
+        search: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><circle cx="10.5" cy="10.5" r="3" stroke="#f8fafc" stroke-width="2"/><path d="M12.5 12.5l4 4" stroke="#f8fafc" stroke-width="2" stroke-linecap="round"/></svg>',
+        tv: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><rect x="7" y="8" width="10" height="6" rx="1" stroke="#f8fafc" stroke-width="1.5"/></svg>',
+        film: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><rect x="7" y="7" width="10" height="10" rx="1" stroke="#f8fafc" stroke-width="1.5"/></svg>',
+        download: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><path d="M12 7v8m0 0l-3-3m3 3l3-3" stroke="#f8fafc" stroke-width="2" stroke-linecap="round"/></svg>',
+        collection: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><rect x="7" y="8" width="10" height="3" rx="0.5" stroke="#f8fafc" stroke-width="1.5"/><rect x="7" y="13" width="10" height="3" rx="0.5" stroke="#f8fafc" stroke-width="1.5"/></svg>',
+        play: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><path d="M10 8l6 4-6 4V8z" fill="#f8fafc"/></svg>',
+        'cloud-download': '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><path d="M8 11a3 3 0 016 0h2c1 0 2 1 2 2s-1 2-2 2H8c-1 0-2-1-2-2s1-2 2-2z" stroke="#f8fafc" stroke-width="1.5"/></svg>',
+        music: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><path d="M9 15V9l6-2v8" stroke="#f8fafc" stroke-width="1.5" stroke-linecap="round"/></svg>',
+        book: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><path d="M12 8v8M12 8c-1-1-2-1-3-1M12 8c1-1 2-1 3-1" stroke="#f8fafc" stroke-width="1.5" stroke-linecap="round"/></svg>',
+        default: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="9" stroke="rgba(248,250,252,0.72)" stroke-width="2" fill="rgba(15,23,42,0.3)"/><rect x="7" y="10" width="10" height="4" rx="0.5" stroke="#f8fafc" stroke-width="1.5"/></svg>',
+    };
+}
+
+function getIcon(containerName) {
+    const iconSVGs = window.ThemeIcons || getDefaultIcons();
+    const service = serviceOverrides[containerName];
+    if (service && service.icon && iconSVGs[service.icon]) {
+        return iconSVGs[service.icon];
+    }
+    return iconSVGs.default;
+}
+
+function getFriendlyName(containerName) {
+    const service = serviceOverrides[containerName];
+    if (service && service.name) {
+        return service.name;
+    }
+
+    return containerName
+        .replace(/[-_]/g, ' ')
+        .replace(/\w\S*/g, (word) => word.replace(/^\w/, (c) => c.toUpperCase()));
+}
+
+function getBackgroundGradient(containerName) {
+    const gradients = window.ThemeLoader ? window.ThemeLoader.getThemeGradients() : [
+        'from-sky-700 to-cyan-700',
+        'from-teal-700 to-emerald-700',
+        'from-orange-700 to-amber-700',
+        'from-indigo-700 to-sky-700',
+        'from-emerald-700 to-teal-700',
+        'from-cyan-700 to-blue-700',
+    ];
+
+    let hash = 0;
+    for (let i = 0; i < containerName.length; i += 1) {
+        hash = containerName.charCodeAt(i) + ((hash << 5) - hash);
+    }
+
+    return gradients[Math.abs(hash) % gradients.length];
+}
+
+function getWebUIPort(container) {
+    if (!container.ports || container.ports.length === 0) {
+        return null;
+    }
+
+    const tcpPorts = container.ports.filter((port) => port.protocol !== 'udp');
+    const hostTcp = tcpPorts.find((port) => port.host_port);
+    if (hostTcp) return hostTcp.host_port;
+
+    const anyHost = container.ports.find((port) => port.host_port);
+    if (anyHost) return anyHost.host_port;
+
+    const tcpContainer = tcpPorts.find((port) => port.container_port);
+    if (tcpContainer) return tcpContainer.container_port;
+
+    const fallback = container.ports.find((port) => port.container_port);
+    return fallback ? fallback.container_port : null;
+}
+
+function buildServiceCard(container) {
+    const port = getWebUIPort(container);
+    const icon = getIcon(container.name);
+    const friendlyName = getFriendlyName(container.name);
+    const gradient = getBackgroundGradient(container.name);
+
+    const card = document.createElement('article');
+    card.className = 'ph-service-card';
+    card.innerHTML = `
+        <div class="ph-service-banner bg-gradient-to-br ${gradient}">
+            ${icon}
+        </div>
+        <div class="ph-service-content">
+            <h3 class="ph-service-title">${friendlyName}</h3>
+            <p class="ph-service-port">port:${port}</p>
+            <a class="ph-service-link" href="http://${window.location.hostname}:${port}" target="_blank" rel="noopener noreferrer">Open Service</a>
+        </div>
+    `;
+
+    return card;
+}
+
+async function fetchDockerWebServices() {
+    try {
+        renderState('Loading services...');
+        const response = await window.apiFetch('/api/containers?stats=false');
+        const containers = await response.json();
+
+        if (!Array.isArray(containers)) {
+            throw new Error(containers.error || 'Invalid response while loading containers.');
+        }
+
+        const webServices = containers.filter((container) => container.status === 'running' && getWebUIPort(container));
+        serviceCount.textContent = String(webServices.length);
+        refreshTime.textContent = formatRefreshTime(new Date());
+
+        if (!webServices.length) {
+            renderState(
+                'No running web services found.',
+                'info',
+                '<a class="ph-action-link" href="/containers.html">Manage Containers</a>'
+            );
+            return;
+        }
+
+        serviceGrid.innerHTML = '';
+        webServices.forEach((container) => serviceGrid.appendChild(buildServiceCard(container)));
+    } catch (error) {
+        console.error('Error fetching Docker services:', error);
+        renderState(`Error loading services: ${error.message}`, 'error');
+    }
+}
+
+(async function initIndexPage() {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+        return;
+    }
+
+    window.logout = logoutToLogin;
+
+    await fetchDockerWebServices();
+    window.setInterval(fetchDockerWebServices, 30000);
+})();

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -170,6 +170,11 @@ class TestStaticPages:
         """Test index page loads."""
         response = client.get('/')
         assert response.status_code == 200
+        body = response.data.decode('utf-8')
+        assert '/css/foundation.css' in body
+        assert '/css/index.css' in body
+        assert 'type="module" src="/js/pages/index.js"' in body
+        assert 'Docker Web Services' in body
 
     def test_containers_page(self, client):
         """Test containers page loads."""


### PR DESCRIPTION
Summary
- migrate static index page to foundation-based layout and styling
- move dashboard logic into modular script at static/js/pages/index.js
- add shared auth utility for route guard and logout integration
- preserve service icon mapping, port discovery, and launch actions
- update migration tracker and index page assertions in tests

Validation
- tox -e all (run by commit hook)
- ruff passed
- pytest: 502 passed, 1 skipped, 52 deselected
- e2e skipped in sandbox because app could not bind test port

Notes
- This PR is stacked on feat/ui-modernization-foundation (PR #33).