### PR TITLE
Add shared UI shell and reusable state components

### DIFF
--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -11,8 +11,8 @@
 - [x] Choose final UI stack (Flask + static HTML + vanilla ES modules + shared CSS tokens).
 - [x] Establish design tokens (color, spacing, radius, typography).
 - [x] Create shared API client baseline (`static/js/lib/http.js`).
-- [ ] Create shared layout shell (header/nav/content/footer).
-- [ ] Create reusable shared state components (`LoadingState`, `ErrorState`, `EmptyState`).
+- [x] Create shared layout shell (header/nav/content/footer).
+- [x] Create reusable shared state components (`LoadingState`, `ErrorState`, `EmptyState`).
 - [ ] Add UI smoke tests for core routes.
 
 ## Page checklist

--- a/Docs/UI_MODERNIZATION_PLAN.md
+++ b/Docs/UI_MODERNIZATION_PLAN.md
@@ -23,6 +23,8 @@ For this migration wave, the UI stack is:
 - Login, Dashboard, System, and Containers are migrated to module-based page scripts.
 - Shared auth/session helpers exist in `static/js/lib/auth.js` and `static/js/lib/session.js`.
 - Shared HTTP helper exists in `static/js/lib/http.js`.
+- Shared layout helper exists in `static/js/lib/layout.js`.
+- Shared state components exist in `static/js/lib/states.js`.
 - Legacy utility script `static/js/api.js` still exists for older pages and shared toast UI.
 
 ## Standards for migrated pages

--- a/static/js/lib/layout.js
+++ b/static/js/lib/layout.js
@@ -1,0 +1,122 @@
+const DEFAULT_BODY_CLASS = 'bg-gray-900 text-blue-100 font-sans min-h-screen';
+const DEFAULT_NAV_CLASS = 'bg-purple-900 shadow-md';
+const DEFAULT_NOTIFICATION_CLASS = 'fixed top-4 right-4 z-50 w-72 flex flex-col items-end';
+const DEFAULT_FOOTER_CLASS = 'text-center text-xs text-gray-500 py-6';
+
+function applyClassList(element, classNames) {
+    if (!element || !classNames) {
+        return;
+    }
+    element.className = classNames;
+}
+
+function ensureBodyClasses(classNames) {
+    if (!classNames) {
+        return;
+    }
+
+    classNames.split(/\s+/).filter(Boolean).forEach((name) => {
+        document.body.classList.add(name);
+    });
+}
+
+function ensureHeader(beforeNode) {
+    let header = document.querySelector('header[data-shell-header="dashboard"]');
+    if (header) {
+        return header;
+    }
+
+    header = document.querySelector('header');
+    if (header) {
+        header.dataset.shellHeader = 'dashboard';
+        return header;
+    }
+
+    const created = document.createElement('header');
+    created.dataset.shellHeader = 'dashboard';
+    created.className = 'bg-gradient-to-r from-purple-900 to-blue-900 shadow-lg relative overflow-hidden';
+    created.innerHTML = `
+        <div class="absolute inset-0 overflow-hidden">
+            <img src="/theme-banner" alt="Dashboard" class="w-full h-full object-cover opacity-40 blur-sm" style="filter: hue-rotate(-10deg) saturate(1.15);">
+        </div>
+        <div class="container mx-auto px-8 py-12 relative"></div>
+    `;
+
+    document.body.insertBefore(created, beforeNode || document.body.firstChild);
+    return created;
+}
+
+function ensureNav(beforeNode, navClass) {
+    let nav = document.getElementById('main-nav');
+    if (!nav) {
+        nav = document.createElement('nav');
+        nav.id = 'main-nav';
+        document.body.insertBefore(nav, beforeNode);
+    }
+
+    applyClassList(nav, navClass || DEFAULT_NAV_CLASS);
+    nav.dataset.shellNav = 'dashboard';
+    return nav;
+}
+
+function ensureNotification(afterNode, notificationClass) {
+    let notificationArea = document.getElementById('notification-area');
+    if (!notificationArea) {
+        notificationArea = document.createElement('div');
+        notificationArea.id = 'notification-area';
+        if (afterNode?.nextSibling) {
+            document.body.insertBefore(notificationArea, afterNode.nextSibling);
+        } else {
+            document.body.appendChild(notificationArea);
+        }
+    }
+
+    applyClassList(notificationArea, notificationClass || DEFAULT_NOTIFICATION_CLASS);
+    notificationArea.dataset.shellNotifications = 'dashboard';
+    return notificationArea;
+}
+
+function ensureFooter(main, { includeFooter, footerText, footerClass } = {}) {
+    if (!includeFooter) {
+        return null;
+    }
+
+    let footer = document.querySelector('footer[data-shell-footer="dashboard"]');
+    if (!footer) {
+        footer = document.createElement('footer');
+        footer.dataset.shellFooter = 'dashboard';
+        if (main?.nextSibling) {
+            document.body.insertBefore(footer, main.nextSibling);
+        } else {
+            document.body.appendChild(footer);
+        }
+    }
+
+    applyClassList(footer, footerClass || DEFAULT_FOOTER_CLASS);
+    footer.textContent = footerText || `Pi-Health UI`;
+    return footer;
+}
+
+export function ensureDashboardShell(options = {}) {
+    const main = document.querySelector('main');
+    if (!main) {
+        return null;
+    }
+
+    const bodyClass = options.bodyClass || DEFAULT_BODY_CLASS;
+    ensureBodyClasses(bodyClass);
+
+    const header = ensureHeader(main);
+    const nav = ensureNav(main, options.navClass);
+    const notifications = ensureNotification(nav, options.notificationClass);
+    const footer = ensureFooter(main, options);
+
+    return {
+        body: document.body,
+        header,
+        nav,
+        notifications,
+        main,
+        footer,
+    };
+}

--- a/static/js/lib/states.js
+++ b/static/js/lib/states.js
@@ -1,0 +1,92 @@
+export function clearElement(node) {
+    if (!node) {
+        return;
+    }
+
+    while (node.firstChild) {
+        node.removeChild(node.firstChild);
+    }
+}
+
+function addOptionalSubtitle(wrapper, subtitle, subtitleClass) {
+    if (!subtitle) {
+        return;
+    }
+
+    const subtitleEl = document.createElement('p');
+    subtitleEl.className = subtitleClass;
+    subtitleEl.textContent = subtitle;
+    wrapper.appendChild(subtitleEl);
+}
+
+function addOptionalAction(wrapper, action, actionClass) {
+    if (!action?.href || !action?.label) {
+        return;
+    }
+
+    const link = document.createElement('a');
+    link.className = actionClass;
+    link.href = action.href;
+    link.textContent = action.label;
+    wrapper.appendChild(link);
+}
+
+export function createLoadingState({
+    message = 'Loading...',
+    containerClass = 'col-span-full text-center py-10',
+    messageClass = 'text-gray-400',
+} = {}) {
+    const wrapper = document.createElement('div');
+    wrapper.className = containerClass;
+
+    const messageEl = document.createElement('p');
+    messageEl.className = messageClass;
+    messageEl.textContent = message;
+    wrapper.appendChild(messageEl);
+
+    return wrapper;
+}
+
+export function createEmptyState({
+    title = 'No data found.',
+    subtitle = '',
+    action = null,
+    containerClass = 'col-span-full text-center py-10',
+    titleClass = 'mt-4 text-xl',
+    subtitleClass = 'text-gray-400 mt-2',
+    actionClass = 'text-blue-300 underline hover:text-blue-200 mt-2 inline-block',
+} = {}) {
+    const wrapper = document.createElement('div');
+    wrapper.className = containerClass;
+
+    const titleEl = document.createElement('p');
+    titleEl.className = titleClass;
+    titleEl.textContent = title;
+    wrapper.appendChild(titleEl);
+
+    addOptionalSubtitle(wrapper, subtitle, subtitleClass);
+    addOptionalAction(wrapper, action, actionClass);
+    return wrapper;
+}
+
+export function createErrorState({
+    title = 'Something went wrong.',
+    subtitle = '',
+    action = null,
+    containerClass = 'col-span-full text-center py-10',
+    titleClass = 'text-red-400',
+    subtitleClass = 'text-gray-400 mt-2',
+    actionClass = 'text-blue-300 underline hover:text-blue-200 mt-2 inline-block',
+} = {}) {
+    const wrapper = document.createElement('div');
+    wrapper.className = containerClass;
+
+    const titleEl = document.createElement('p');
+    titleEl.className = titleClass;
+    titleEl.textContent = title;
+    wrapper.appendChild(titleEl);
+
+    addOptionalSubtitle(wrapper, subtitle, subtitleClass);
+    addOptionalAction(wrapper, action, actionClass);
+    return wrapper;
+}

--- a/static/js/pages/apps.js
+++ b/static/js/pages/apps.js
@@ -1,5 +1,12 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 import { requestJson } from '/js/lib/http.js';
+
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 w-72 flex flex-col items-end',
+    includeFooter: true,
+});
 
 let catalogItems = [];
 let installedServices = [];
@@ -55,20 +62,10 @@ async function requestApiJson(url, options = {}) {
     return payload;
 }
 
-function clearElement(node) {
-    while (node.firstChild) {
-        node.removeChild(node.firstChild);
-    }
-}
-
 function showLoadingState(message = 'Loading catalog...') {
     const grid = document.getElementById('catalog-grid');
     clearElement(grid);
-
-    const item = document.createElement('div');
-    item.className = 'col-span-full text-center py-10 text-gray-400';
-    item.textContent = message;
-    grid.appendChild(item);
+    grid.appendChild(createLoadingState({ message }));
 }
 
 function getItemStacks(itemId) {
@@ -92,7 +89,12 @@ async function loadCatalog() {
 
         renderCatalog();
     } catch (_error) {
-        showLoadingState('Failed to load catalog.');
+        const grid = document.getElementById('catalog-grid');
+        clearElement(grid);
+        grid.appendChild(createErrorState({
+            title: 'Failed to load catalog.',
+            subtitle: 'Refresh the page and try again.',
+        }));
     }
 }
 
@@ -175,10 +177,11 @@ function renderCatalog() {
     clearElement(grid);
 
     if (!catalogItems.length) {
-        const empty = document.createElement('div');
-        empty.className = 'col-span-full text-center py-10 text-gray-400';
-        empty.textContent = 'No catalog items found. Add templates under catalog/.';
-        grid.appendChild(empty);
+        grid.appendChild(createEmptyState({
+            title: 'No catalog items found.',
+            subtitle: 'Add templates under catalog/.',
+            titleClass: 'text-gray-300 text-lg',
+        }));
         return;
     }
 

--- a/static/js/pages/settings.js
+++ b/static/js/pages/settings.js
@@ -1,6 +1,13 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearElement } from '/js/lib/states.js';
 import { requestJson } from '/js/lib/http.js';
 import { clearClientSession } from '/js/lib/session.js';
+
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 space-y-2',
+    includeFooter: true,
+});
 
 let currentConfig = {};
 let backupConfig = {};
@@ -57,12 +64,6 @@ async function requestApiJson(url, options = {}) {
     }
 
     return payload;
-}
-
-function clearElement(node) {
-    while (node.firstChild) {
-        node.removeChild(node.firstChild);
-    }
 }
 
 function setButtonBusy(button, busy) {

--- a/static/js/pages/stacks.js
+++ b/static/js/pages/stacks.js
@@ -1,5 +1,12 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearElement, createEmptyState, createErrorState } from '/js/lib/states.js';
 import { requestJson } from '/js/lib/http.js';
+
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
+    includeFooter: true,
+});
 
 let stacks = [];
 let currentStack = null;
@@ -35,31 +42,6 @@ function statusClass(status) {
     return `status-${value}`;
 }
 
-function clearElement(node) {
-    while (node.firstChild) {
-        node.removeChild(node.firstChild);
-    }
-}
-
-function createEmptyState({ title, subtitle, error = false }) {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'col-span-full text-center py-10';
-
-    const titleEl = document.createElement('p');
-    titleEl.className = error ? 'text-red-400' : 'mt-4 text-xl';
-    titleEl.textContent = title;
-    wrapper.appendChild(titleEl);
-
-    if (subtitle) {
-        const subtitleEl = document.createElement('p');
-        subtitleEl.className = 'text-gray-400 mt-2';
-        subtitleEl.textContent = subtitle;
-        wrapper.appendChild(subtitleEl);
-    }
-
-    return wrapper;
-}
-
 function formatNowTime() {
     return new Date().toLocaleTimeString();
 }
@@ -84,10 +66,9 @@ async function loadStacks() {
     } catch (error) {
         console.error('Error loading stacks:', error);
         clearElement(grid);
-        grid.appendChild(createEmptyState({
+        grid.appendChild(createErrorState({
             title: `Error loading stacks: ${error.message}`,
             subtitle: 'Make sure STACKS_PATH is configured and accessible.',
-            error: true,
         }));
     } finally {
         refreshBtn.classList.remove('animate-pulse');
@@ -102,6 +83,7 @@ function renderStacks() {
         grid.appendChild(createEmptyState({
             title: 'No stacks found',
             subtitle: 'Create a new stack or check your STACKS_PATH configuration.',
+            titleClass: 'mt-4 text-xl',
         }));
         return;
     }


### PR DESCRIPTION
## Summary
- add shared shell helper in `static/js/lib/layout.js` to standardize header/nav/notifications/footer wiring
- add reusable state components in `static/js/lib/states.js` (`LoadingState`, `ErrorState`, `EmptyState`, plus `clearElement`)
- adopt shared shell + state components in migrated pages:
  - `static/js/pages/apps.js`
  - `static/js/pages/stacks.js`
  - `static/js/pages/settings.js`
- mark shared foundation items complete in `Docs/UI_MIGRATION_TRACKER.md`
- document the new shared helpers in `Docs/UI_MODERNIZATION_PLAN.md`

## Why
This establishes the shared UI groundwork before continuing page migrations, reducing duplicate UI scaffolding and making state rendering consistent across pages.

## Testing
- `pytest -q tests/test_app.py::TestStaticPages::test_apps_page_vpn_config_modal tests/test_app.py::TestStaticPages::test_settings_page_setup_hooks tests/test_stacks.py::TestStacksPage::test_stacks_page_loads`
- pre-commit hook ran `tox -e all` (non-e2e suite passed; e2e skipped in sandbox)
