### PR TITLE
Migrate disks page to modular JS/CSS

### DIFF
--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -56,7 +56,10 @@
 - [x] Migrate `mounts`.
 - [x] Migrate `shares`.
 - [x] Migrate `plugins`.
-- [ ] Migrate `disks`, `network`, `tailscale`, `tools`.
+- [x] Migrate `disks`.
+- [ ] Migrate `network`.
+- [ ] Migrate `tailscale`.
+- [ ] Migrate `tools`.
 - [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
 - [ ] Validate plugin-specific edge cases.
 

--- a/static/css/disks.css
+++ b/static/css/disks.css
@@ -1,0 +1,102 @@
+.coraline-button {
+    background: linear-gradient(to bottom, #5f4b8b, #372b53);
+    border: 1px solid #8a6cbd;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
+    transition: all 0.3s ease;
+}
+
+.coraline-button:hover {
+    background: linear-gradient(to bottom, #6f58a3, #413162);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
+}
+
+.disk-card {
+    transition: all 0.2s ease;
+}
+
+.disk-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+}
+
+.progress-bar {
+    height: 8px;
+    border-radius: 4px;
+    background: #374151;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    transition: width 0.3s ease;
+}
+
+.mounted {
+    color: #34d399;
+}
+
+.unmounted {
+    color: #fbbf24;
+}
+
+.missing {
+    color: #f87171;
+}
+
+.smart-healthy {
+    color: #34d399;
+}
+
+.smart-warning {
+    color: #fbbf24;
+}
+
+.smart-failing {
+    color: #f87171;
+}
+
+.smart-unknown {
+    color: #9ca3af;
+}
+
+.smart-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.smart-badge.healthy {
+    background-color: rgba(52, 211, 153, 0.2);
+    color: #34d399;
+    border: 1px solid #34d399;
+}
+
+.smart-badge.warning {
+    background-color: rgba(251, 191, 36, 0.2);
+    color: #fbbf24;
+    border: 1px solid #fbbf24;
+}
+
+.smart-badge.failing {
+    background-color: rgba(248, 113, 113, 0.2);
+    color: #f87171;
+    border: 1px solid #f87171;
+}
+
+.smart-badge.unknown {
+    background-color: rgba(156, 163, 175, 0.2);
+    color: #9ca3af;
+    border: 1px solid #9ca3af;
+}
+
+.smart-attr-row:hover {
+    background-color: rgba(139, 92, 246, 0.1);
+}
+
+.smart-attr-critical {
+    background-color: rgba(248, 113, 113, 0.1);
+}

--- a/static/disks.html
+++ b/static/disks.html
@@ -1,87 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        if (!sessionStorage.getItem("loggedIn")) {
-            window.location.href = "/login.html";
-        }
-
-        const username = sessionStorage.getItem("username");
-        if (username) {
-            document.addEventListener('DOMContentLoaded', () => {
-                const userEl = document.getElementById('logged-in-user');
-                if (userEl) userEl.textContent = username;
-            });
-        }
-
-        async function logout() {
-            try {
-                await fetch('/api/logout', { method: 'POST' });
-            } catch (e) {}
-            sessionStorage.clear();
-            window.location.href = '/login.html';
-        }
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Disks - Pi-Health Dashboard</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="stylesheet" href="/css/foundation.css">
+    <link rel="stylesheet" href="/css/disks.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
-    <style>
-        .coraline-button {
-            background: linear-gradient(to bottom, #5f4b8b, #372b53);
-            border: 1px solid #8a6cbd;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
-            transition: all 0.3s ease;
-        }
-        .coraline-button:hover {
-            background: linear-gradient(to bottom, #6f58a3, #413162);
-            transform: translateY(-2px);
-            box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
-        }
-        .disk-card {
-            transition: all 0.2s ease;
-        }
-        .disk-card:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
-        }
-        .progress-bar {
-            height: 8px;
-            border-radius: 4px;
-            background: #374151;
-            overflow: hidden;
-        }
-        .progress-fill {
-            height: 100%;
-            transition: width 0.3s ease;
-        }
-        .mounted { color: #34d399; }
-        .unmounted { color: #fbbf24; }
-        .missing { color: #f87171; }
-        /* SMART health status colors */
-        .smart-healthy { color: #34d399; }
-        .smart-warning { color: #fbbf24; }
-        .smart-failing { color: #f87171; }
-        .smart-unknown { color: #9ca3af; }
-        .smart-badge {
-            display: inline-flex;
-            align-items: center;
-            padding: 0.25rem 0.75rem;
-            border-radius: 9999px;
-            font-size: 0.75rem;
-            font-weight: 500;
-        }
-        .smart-badge.healthy { background-color: rgba(52, 211, 153, 0.2); color: #34d399; border: 1px solid #34d399; }
-        .smart-badge.warning { background-color: rgba(251, 191, 36, 0.2); color: #fbbf24; border: 1px solid #fbbf24; }
-        .smart-badge.failing { background-color: rgba(248, 113, 113, 0.2); color: #f87171; border: 1px solid #f87171; }
-        .smart-badge.unknown { background-color: rgba(156, 163, 175, 0.2); color: #9ca3af; border: 1px solid #9ca3af; }
-        .smart-attr-row:hover { background-color: rgba(139, 92, 246, 0.1); }
-        .smart-attr-critical { background-color: rgba(248, 113, 113, 0.1); }
-    </style>
 </head>
 <body class="bg-gray-900 text-blue-100 font-sans min-h-screen">
     <header class="bg-gradient-to-r from-purple-900 to-blue-900 shadow-lg relative overflow-hidden">
@@ -97,11 +26,9 @@
     <div id="notification-area" class="fixed top-4 right-4 z-50 w-80 flex flex-col items-end"></div>
 
     <main class="container mx-auto p-6">
-        <!-- Helper Status Banner -->
         <div id="helper-status" class="hidden mb-6 p-4 rounded-lg border">
         </div>
 
-        <!-- Header -->
         <div class="mb-6 flex justify-between items-center">
             <div>
                 <h2 class="text-2xl font-semibold">Disk Management</h2>
@@ -117,7 +44,6 @@
             </div>
         </div>
 
-        <!-- Disk Inventory -->
         <section class="mb-8">
             <h3 class="text-lg font-semibold mb-4">Storage Devices</h3>
             <div id="disk-list" class="space-y-4">
@@ -125,7 +51,6 @@
             </div>
         </section>
 
-        <!-- SMART Health -->
         <section class="mb-8 bg-gray-800 rounded-lg p-6 border border-purple-900/40">
             <div class="flex justify-between items-center mb-4">
                 <div>
@@ -144,14 +69,12 @@
             </div>
         </section>
 
-        <!-- Mount Suggestions -->
         <section id="suggestions-section" class="hidden mb-8">
             <h3 class="text-lg font-semibold mb-4">Mount Suggestions</h3>
             <div id="suggestions-list" class="space-y-3"></div>
         </section>
     </main>
 
-    <!-- Mount Modal -->
     <div id="mount-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 items-center justify-center p-4">
         <div class="bg-gray-900 w-full max-w-lg rounded-lg shadow-xl border border-purple-900 flex flex-col">
             <div class="flex justify-between items-center p-4 border-b border-purple-800">
@@ -187,7 +110,6 @@
         </div>
     </div>
 
-    <!-- SMART Detail Modal -->
     <div id="smart-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 items-center justify-center p-4 overflow-hidden" onclick="if(event.target === this) closeSmartModal()">
         <div class="bg-gray-900 w-full max-w-2xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh]" onclick="event.stopPropagation()">
             <div class="flex justify-between items-center p-4 border-b border-purple-800 flex-shrink-0">
@@ -196,7 +118,6 @@
             </div>
             <div class="p-4 overflow-y-auto flex-1 min-h-0">
                 <div id="smart-modal-content">
-                    <!-- Filled by JS -->
                 </div>
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-between items-center flex-shrink-0">
@@ -209,536 +130,6 @@
         </div>
     </div>
 
-    <script>
-        let diskInventory = [];
-
-        function showNotification(message, type = 'info') {
-            const area = document.getElementById('notification-area');
-            const notification = document.createElement('div');
-            notification.className = `p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0`;
-            if (type === 'success') notification.classList.add('bg-green-600');
-            else if (type === 'error') notification.classList.add('bg-red-600');
-            else notification.classList.add('bg-blue-600');
-            notification.textContent = message;
-            area.appendChild(notification);
-            setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-            setTimeout(() => {
-                notification.classList.replace('opacity-100', 'opacity-0');
-                setTimeout(() => notification.remove(), 300);
-            }, 3000);
-        }
-
-        function formatBytes(bytes) {
-            if (!bytes || bytes === 0) return '0 B';
-            const k = 1024;
-            const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-            const i = Math.floor(Math.log(bytes) / Math.log(k));
-            return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-        }
-
-        function escapeHtml(str) {
-            if (!str) return '';
-            return String(str)
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;');
-        }
-
-        async function loadDisks() {
-            const diskList = document.getElementById('disk-list');
-            diskList.innerHTML = '<div class="text-center py-10 text-gray-400">Loading...</div>';
-
-            try {
-                const response = await fetch('/api/disks');
-                const data = await response.json();
-
-                // Check helper status
-                const helperStatus = document.getElementById('helper-status');
-                if (!data.helper_available) {
-                    helperStatus.className = 'mb-6 p-4 rounded-lg border bg-yellow-900/30 border-yellow-700';
-                    helperStatus.innerHTML = `
-                        <div class="flex items-center">
-                            <svg class="w-5 h-5 mr-2 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                            </svg>
-                            <div>
-                                <p class="font-medium text-yellow-300">Helper Service Not Running</p>
-                                <p class="text-sm text-yellow-200/70">Disk management requires the pihealth-helper service. Start it with: <code class="bg-gray-800 px-1 rounded">sudo systemctl start pihealth-helper</code></p>
-                            </div>
-                        </div>
-                    `;
-                    helperStatus.classList.remove('hidden');
-                    diskList.innerHTML = '<div class="text-center py-10 text-gray-500">Helper service required for disk information</div>';
-                    return;
-                }
-
-                helperStatus.classList.add('hidden');
-                diskInventory = data.disks || [];
-
-                if (!diskInventory.length) {
-                    diskList.innerHTML = '<div class="text-center py-10 text-gray-400">No storage devices found</div>';
-                    return;
-                }
-
-                renderDisks();
-                loadSuggestions();
-            } catch (error) {
-                diskList.innerHTML = `<div class="text-center py-10 text-red-400">Error loading disks: ${escapeHtml(error.message)}</div>`;
-            }
-        }
-
-        function renderDisks() {
-            const diskList = document.getElementById('disk-list');
-
-            diskList.innerHTML = diskInventory.map(disk => {
-                // Filter out empty partitions list for display
-                const hasPartitions = disk.partitions && disk.partitions.length > 0;
-                const displayItems = hasPartitions ? disk.partitions : [disk];
-
-                return `
-                    <div class="disk-card bg-gray-800 rounded-lg border border-purple-900/40 overflow-hidden">
-                        <div class="p-4 bg-gray-800/50 border-b border-gray-700">
-                            <div class="flex justify-between items-start">
-                                <div>
-                                    <h4 class="font-semibold text-lg">${escapeHtml(disk.path)}</h4>
-                                    <p class="text-sm text-gray-400">${escapeHtml(disk.model || 'Unknown device')} ${disk.serial ? '(' + escapeHtml(disk.serial) + ')' : ''}</p>
-                                </div>
-                                <div class="text-right">
-                                    <span class="text-lg font-medium">${escapeHtml(disk.size)}</span>
-                                    <p class="text-xs text-gray-500">${escapeHtml(disk.transport || 'unknown')} ${disk.hotplug ? '(removable)' : ''}</p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="divide-y divide-gray-700">
-                            ${displayItems.map(part => renderPartition(part, disk)).join('')}
-                        </div>
-                    </div>
-                `;
-            }).join('');
-        }
-
-        function renderPartition(part, parentDisk) {
-            const mounted = part.mounted;
-            const statusClass = mounted ? 'mounted' : 'unmounted';
-            const statusText = mounted ? 'Mounted' : 'Not Mounted';
-
-            let usageBar = '';
-            if (part.usage) {
-                const percent = parseInt(part.usage.percent) || 0;
-                const colorClass = percent > 90 ? 'bg-red-500' : percent > 70 ? 'bg-yellow-500' : 'bg-green-500';
-                usageBar = `
-                    <div class="mt-2">
-                        <div class="flex justify-between text-xs text-gray-400 mb-1">
-                            <span>${formatBytes(part.usage.used)} used</span>
-                            <span>${formatBytes(part.usage.available)} free</span>
-                        </div>
-                        <div class="progress-bar">
-                            <div class="progress-fill ${colorClass}" style="width: ${percent}%"></div>
-                        </div>
-                    </div>
-                `;
-            }
-
-            const actions = mounted
-                ? `<button onclick="unmountDisk('${escapeHtml(part.mountpoint)}')" class="px-3 py-1 text-sm rounded bg-red-700 hover:bg-red-600 text-white">Unmount</button>`
-                : part.uuid
-                    ? `<button onclick="openMountModal('${escapeHtml(part.path)}', '${escapeHtml(part.uuid)}', '${escapeHtml(part.fstype || 'ext4')}')" class="coraline-button px-3 py-1 text-sm rounded text-white">Mount</button>`
-                    : `<span class="text-xs text-gray-500">No filesystem</span>`;
-
-            return `
-                <div class="p-4">
-                    <div class="flex justify-between items-start">
-                        <div class="flex-1">
-                            <div class="flex items-center space-x-2">
-                                <span class="font-medium">${escapeHtml(part.path || part.name)}</span>
-                                <span class="text-xs px-2 py-0.5 rounded ${part.fstype ? 'bg-blue-900 text-blue-300' : 'bg-gray-700 text-gray-400'}">${escapeHtml(part.fstype || 'unknown')}</span>
-                                <span class="text-xs ${statusClass}">${statusText}</span>
-                            </div>
-                            ${part.mountpoint ? `<p class="text-sm text-gray-400 mt-1">Mounted at: ${escapeHtml(part.mountpoint)}</p>` : ''}
-                            ${part.uuid ? `<p class="text-xs text-gray-500 mt-1">UUID: ${escapeHtml(part.uuid)}</p>` : ''}
-                            ${usageBar}
-                        </div>
-                        <div class="ml-4 flex items-center space-x-2">
-                            <span class="text-sm text-gray-400">${escapeHtml(part.size)}</span>
-                            ${actions}
-                        </div>
-                    </div>
-                </div>
-            `;
-        }
-
-        async function loadSuggestions() {
-            try {
-                const response = await fetch('/api/disks/suggested-mounts');
-                const data = await response.json();
-                const suggestions = data.suggestions || [];
-
-                const section = document.getElementById('suggestions-section');
-                const list = document.getElementById('suggestions-list');
-
-                if (!suggestions.length) {
-                    section.classList.add('hidden');
-                    return;
-                }
-
-                section.classList.remove('hidden');
-                list.innerHTML = suggestions.map(s => `
-                    <div class="bg-gray-800 rounded-lg p-4 border border-purple-900/40 flex justify-between items-center">
-                        <div>
-                            <p class="font-medium">${escapeHtml(s.device)} <span class="text-gray-400">(${escapeHtml(s.size)})</span></p>
-                            <p class="text-sm text-gray-400">${escapeHtml(s.reason)}</p>
-                        </div>
-                        <button onclick="openMountModal('${escapeHtml(s.device)}', '${escapeHtml(s.uuid)}', '${escapeHtml(s.fstype)}', '${escapeHtml(s.suggested_mount)}')"
-                                class="coraline-button px-3 py-1 text-sm rounded text-white">
-                            Mount as ${escapeHtml(s.suggested_mount)}
-                        </button>
-                    </div>
-                `).join('');
-            } catch (error) {
-                console.error('Failed to load suggestions:', error);
-            }
-        }
-
-        let currentMount = {};
-
-        function openMountModal(device, uuid, fstype, suggestedMount = '') {
-            currentMount = { device, uuid, fstype };
-            document.getElementById('mount-device').value = device;
-            document.getElementById('mount-uuid').value = uuid;
-            document.getElementById('mount-fstype').value = fstype;
-            document.getElementById('mount-point').value = suggestedMount || '/mnt/';
-            document.getElementById('mount-modal').classList.remove('hidden');
-            document.getElementById('mount-modal').classList.add('flex');
-        }
-
-        function closeMountModal() {
-            document.getElementById('mount-modal').classList.add('hidden');
-            document.getElementById('mount-modal').classList.remove('flex');
-            currentMount = {};
-        }
-
-        async function submitMount() {
-            const mountpoint = document.getElementById('mount-point').value;
-            const addToFstab = document.getElementById('mount-fstab').checked;
-
-            if (!mountpoint || !mountpoint.startsWith('/mnt/')) {
-                showNotification('Mountpoint must start with /mnt/', 'error');
-                return;
-            }
-
-            try {
-                const response = await fetch('/api/disks/mount', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        uuid: currentMount.uuid,
-                        mountpoint: mountpoint,
-                        fstype: currentMount.fstype,
-                        add_to_fstab: addToFstab
-                    })
-                });
-                const data = await response.json();
-                if (!response.ok) throw new Error(data.error);
-
-                showNotification(`Mounted at ${mountpoint}`, 'success');
-                closeMountModal();
-                loadDisks();
-            } catch (error) {
-                showNotification(`Mount failed: ${error.message}`, 'error');
-            }
-        }
-
-        async function unmountDisk(mountpoint) {
-            if (!confirm(`Unmount ${mountpoint}? Make sure no applications are using this storage.`)) {
-                return;
-            }
-
-            try {
-                const response = await fetch('/api/disks/unmount', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        mountpoint: mountpoint,
-                        remove_from_fstab: false
-                    })
-                });
-                const data = await response.json();
-                if (!response.ok) throw new Error(data.error);
-
-                showNotification(`Unmounted ${mountpoint}`, 'success');
-                loadDisks();
-            } catch (error) {
-                showNotification(`Unmount failed: ${error.message}`, 'error');
-            }
-        }
-
-        // ========== SMART Health Functions ==========
-        let smartData = [];
-        let currentSmartDevice = null;
-
-        async function loadSmartData() {
-            const smartList = document.getElementById('smart-list');
-            smartList.innerHTML = '<div class="text-gray-400 text-sm">Loading SMART data...</div>';
-
-            try {
-                const response = await apiFetch('/api/disks/smart');
-                const data = await response.json();
-
-                if (data.error) {
-                    smartList.innerHTML = `<div class="text-red-400 text-sm">${escapeHtml(data.error)}</div>`;
-                    return;
-                }
-
-                smartData = data.disks || [];
-
-                if (!smartData.length) {
-                    smartList.innerHTML = '<div class="text-gray-400 text-sm">No SMART-capable devices found</div>';
-                    return;
-                }
-
-                renderSmartCards();
-            } catch (error) {
-                smartList.innerHTML = `<div class="text-red-400 text-sm">Error: ${escapeHtml(error.message)}</div>`;
-            }
-        }
-
-        function renderSmartCards() {
-            const smartList = document.getElementById('smart-list');
-            smartList.innerHTML = smartData.map(disk => {
-                const data = disk.data || {};
-                const device = disk.device || 'unknown';
-                const deviceName = device.replace('/dev/', '');
-                const status = data.health_status || 'unknown';
-                const statusClass = status === 'healthy' ? 'healthy' : status === 'warning' ? 'warning' : status === 'failing' ? 'failing' : 'unknown';
-
-                // Format power-on hours
-                let powerOnDisplay = 'Unknown';
-                if (data.power_on_hours != null) {
-                    const hours = data.power_on_hours;
-                    const days = Math.floor(hours / 24);
-                    const years = Math.floor(days / 365);
-                    const remainingDays = days % 365;
-                    powerOnDisplay = years > 0 ? `${years}y ${remainingDays}d` : days > 0 ? `${days}d` : `${hours}h`;
-                }
-
-                // Drive type icon
-                const driveIcon = data.drive_type === 'nvme' ? '⚡' : data.drive_type === 'ssd' ? '💾' : data.drive_type === 'hdd' ? '🗄️' : '💿';
-
-                return `
-                    <div class="bg-gray-900 rounded-lg p-4 border border-gray-700 hover:border-purple-600 cursor-pointer transition-colors"
-                         onclick="openSmartModal('${deviceName}')">
-                        <div class="flex justify-between items-start mb-3">
-                            <div class="flex items-center">
-                                <span class="text-2xl mr-2">${driveIcon}</span>
-                                <div>
-                                    <h4 class="font-semibold">${escapeHtml(device)}</h4>
-                                    <p class="text-xs text-gray-400">${escapeHtml(data.model || 'Unknown')}</p>
-                                </div>
-                            </div>
-                            <span class="smart-badge ${statusClass}">${status.toUpperCase()}</span>
-                        </div>
-                        <div class="grid grid-cols-2 gap-2 text-sm">
-                            <div>
-                                <span class="text-gray-400">Temp:</span>
-                                <span class="${data.temperature_c > 55 ? 'text-yellow-400' : 'text-gray-200'}">${data.temperature_c != null ? data.temperature_c + '°C' : 'N/A'}</span>
-                            </div>
-                            <div>
-                                <span class="text-gray-400">Power On:</span>
-                                <span class="text-gray-200">${powerOnDisplay}</span>
-                            </div>
-                            ${data.drive_type === 'nvme' ? `
-                            <div>
-                                <span class="text-gray-400">Used:</span>
-                                <span class="${data.percentage_used > 90 ? 'text-red-400' : 'text-gray-200'}">${data.percentage_used != null ? data.percentage_used + '%' : 'N/A'}</span>
-                            </div>
-                            <div>
-                                <span class="text-gray-400">Spare:</span>
-                                <span class="${data.available_spare < 10 ? 'text-red-400' : 'text-gray-200'}">${data.available_spare != null ? data.available_spare + '%' : 'N/A'}</span>
-                            </div>
-                            ` : `
-                            <div>
-                                <span class="text-gray-400">Realloc:</span>
-                                <span class="${data.reallocated_sectors > 0 ? 'text-yellow-400' : 'text-gray-200'}">${data.reallocated_sectors != null ? data.reallocated_sectors : 'N/A'}</span>
-                            </div>
-                            <div>
-                                <span class="text-gray-400">Pending:</span>
-                                <span class="${data.pending_sectors > 0 ? 'text-yellow-400' : 'text-gray-200'}">${data.pending_sectors != null ? data.pending_sectors : 'N/A'}</span>
-                            </div>
-                            `}
-                        </div>
-                        ${data.error_message ? `<p class="mt-2 text-xs text-yellow-400">${escapeHtml(data.error_message)}</p>` : ''}
-                    </div>
-                `;
-            }).join('');
-        }
-
-        async function openSmartModal(deviceName) {
-            currentSmartDevice = deviceName;
-            const modal = document.getElementById('smart-modal');
-            const title = document.getElementById('smart-modal-title');
-            const content = document.getElementById('smart-modal-content');
-
-            title.textContent = `SMART Details - /dev/${deviceName}`;
-            content.innerHTML = '<div class="text-gray-400">Loading detailed SMART data...</div>';
-
-            modal.classList.remove('hidden');
-            modal.classList.add('flex');
-
-            try {
-                const response = await apiFetch(`/api/disks/${deviceName}/smart`);
-                const data = await response.json();
-
-                if (data.error) {
-                    content.innerHTML = `<div class="text-red-400">${escapeHtml(data.error)}</div>`;
-                    return;
-                }
-
-                renderSmartDetails(data);
-            } catch (error) {
-                content.innerHTML = `<div class="text-red-400">Error: ${escapeHtml(error.message)}</div>`;
-            }
-        }
-
-        function renderSmartDetails(data) {
-            const content = document.getElementById('smart-modal-content');
-            const status = data.health_status || 'unknown';
-            const statusClass = status === 'healthy' ? 'healthy' : status === 'warning' ? 'warning' : status === 'failing' ? 'failing' : 'unknown';
-
-            let html = `
-                <div class="mb-6">
-                    <div class="flex items-center justify-between mb-4">
-                        <div>
-                            <h4 class="font-semibold text-lg">${escapeHtml(data.model || 'Unknown Model')}</h4>
-                            <p class="text-sm text-gray-400">Serial: ${escapeHtml(data.serial || 'Unknown')}</p>
-                        </div>
-                        <span class="smart-badge ${statusClass}">${status.toUpperCase()}</span>
-                    </div>
-                    <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                        <div class="bg-gray-800 p-3 rounded">
-                            <span class="text-gray-400 block">Type</span>
-                            <span class="font-medium">${escapeHtml((data.drive_type || 'unknown').toUpperCase())}</span>
-                        </div>
-                        <div class="bg-gray-800 p-3 rounded">
-                            <span class="text-gray-400 block">Temperature</span>
-                            <span class="font-medium ${data.temperature_c > 55 ? 'text-yellow-400' : ''}">${data.temperature_c != null ? data.temperature_c + '°C' : 'N/A'}</span>
-                        </div>
-                        <div class="bg-gray-800 p-3 rounded">
-                            <span class="text-gray-400 block">Power On Hours</span>
-                            <span class="font-medium">${data.power_on_hours != null ? data.power_on_hours.toLocaleString() : 'N/A'}</span>
-                        </div>
-                        <div class="bg-gray-800 p-3 rounded">
-                            <span class="text-gray-400 block">SMART</span>
-                            <span class="font-medium">${data.smart_enabled ? 'Enabled' : data.smart_available ? 'Available' : 'N/A'}</span>
-                        </div>
-                    </div>
-                </div>
-            `;
-
-            // Show error/warning message if any
-            if (data.error_message) {
-                html += `
-                    <div class="mb-4 p-3 bg-yellow-900/30 border border-yellow-700 rounded text-yellow-300 text-sm">
-                        <strong>Warning:</strong> ${escapeHtml(data.error_message)}
-                    </div>
-                `;
-            }
-
-            // Attributes table
-            if (data.attributes && data.attributes.length > 0) {
-                html += `
-                    <div>
-                        <h5 class="font-semibold mb-2">SMART Attributes</h5>
-                        <div class="overflow-x-auto">
-                            <table class="w-full text-sm">
-                                <thead>
-                                    <tr class="text-gray-400 border-b border-gray-700">
-                                        ${data.drive_type === 'nvme' ? `
-                                            <th class="text-left py-2 px-2">Attribute</th>
-                                            <th class="text-right py-2 px-2">Value</th>
-                                        ` : `
-                                            <th class="text-left py-2 px-1">ID</th>
-                                            <th class="text-left py-2 px-2">Attribute</th>
-                                            <th class="text-right py-2 px-2">Value</th>
-                                            <th class="text-right py-2 px-2">Worst</th>
-                                            <th class="text-right py-2 px-2">Thresh</th>
-                                            <th class="text-right py-2 px-2">Raw</th>
-                                        `}
-                                    </tr>
-                                </thead>
-                                <tbody>
-                `;
-
-                for (const attr of data.attributes) {
-                    const critical = attr.critical ? 'smart-attr-critical' : '';
-                    if (data.drive_type === 'nvme') {
-                        html += `
-                            <tr class="border-b border-gray-800 smart-attr-row ${critical}">
-                                <td class="py-2 px-2">${escapeHtml(attr.name)}</td>
-                                <td class="py-2 px-2 text-right font-mono">${attr.value != null ? attr.value.toLocaleString() : 'N/A'}</td>
-                            </tr>
-                        `;
-                    } else {
-                        html += `
-                            <tr class="border-b border-gray-800 smart-attr-row ${critical}">
-                                <td class="py-2 px-1 text-gray-500">${attr.id || ''}</td>
-                                <td class="py-2 px-2">${escapeHtml(attr.name)}</td>
-                                <td class="py-2 px-2 text-right font-mono">${attr.value != null ? attr.value : ''}</td>
-                                <td class="py-2 px-2 text-right font-mono text-gray-500">${attr.worst != null ? attr.worst : ''}</td>
-                                <td class="py-2 px-2 text-right font-mono text-gray-500">${attr.thresh != null ? attr.thresh : ''}</td>
-                                <td class="py-2 px-2 text-right font-mono ${attr.critical && attr.raw > 0 ? 'text-yellow-400' : ''}">${attr.raw != null ? attr.raw.toLocaleString() : ''}</td>
-                            </tr>
-                        `;
-                    }
-                }
-
-                html += `
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                `;
-            }
-
-            content.innerHTML = html;
-        }
-
-        function closeSmartModal() {
-            const modal = document.getElementById('smart-modal');
-            modal.classList.add('hidden');
-            modal.classList.remove('flex');
-            currentSmartDevice = null;
-        }
-
-        async function runSmartTest(testType) {
-            if (!currentSmartDevice) return;
-
-            if (!confirm(`Run a ${testType} SMART self-test on /dev/${currentSmartDevice}? ${testType === 'long' ? 'This may take several hours.' : 'This typically takes 1-2 minutes.'}`)) {
-                return;
-            }
-
-            try {
-                const response = await apiFetch(`/api/disks/${currentSmartDevice}/smart-test`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ test_type: testType })
-                });
-                const data = await response.json();
-
-                if (!response.ok) {
-                    throw new Error(data.error || 'Failed to start test');
-                }
-
-                showNotification(`${testType.charAt(0).toUpperCase() + testType.slice(1)} SMART test started on /dev/${currentSmartDevice}`, 'success');
-            } catch (error) {
-                showNotification(`Error: ${error.message}`, 'error');
-            }
-        }
-
-        // Load on page ready
-        document.addEventListener('DOMContentLoaded', () => {
-            loadDisks();
-        });
-    </script>
+    <script type="module" src="/js/pages/disks.js"></script>
 </body>
 </html>

--- a/static/js/pages/disks.js
+++ b/static/js/pages/disks.js
@@ -1,0 +1,756 @@
+import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearClientSession } from '/js/lib/session.js';
+import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
+    includeFooter: true,
+});
+
+let diskInventory = [];
+let currentMount = {};
+let smartData = [];
+let currentSmartDevice = null;
+
+async function apiFetch(url, options = {}) {
+    const response = await fetch(url, options);
+    if (response.status === 401) {
+        clearClientSession();
+        window.location.href = '/login.html';
+        throw new Error('Authentication required');
+    }
+    return response;
+}
+
+function showNotification(message, type = 'info') {
+    const area = document.getElementById('notification-area');
+    const notification = document.createElement('div');
+    notification.className = 'p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0';
+    if (type === 'success') notification.classList.add('bg-green-600');
+    else if (type === 'error') notification.classList.add('bg-red-600');
+    else notification.classList.add('bg-blue-600');
+    notification.textContent = message;
+    area.appendChild(notification);
+    setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
+    setTimeout(() => {
+        notification.classList.replace('opacity-100', 'opacity-0');
+        setTimeout(() => notification.remove(), 300);
+    }, 3000);
+}
+
+function formatBytes(bytes) {
+    if (!bytes || bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function encodeDataAttr(value) {
+    return escapeHtml(String(value ?? ''));
+}
+
+function parseDataBool(value, defaultValue = false) {
+    if (value === undefined || value === null || value === '') {
+        return defaultValue;
+    }
+    return value === 'true';
+}
+
+function setNodeContent(containerId, node) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    clearElement(container);
+    container.appendChild(node);
+}
+
+function renderHelperUnavailable() {
+    const helperStatus = document.getElementById('helper-status');
+    if (!helperStatus) {
+        return;
+    }
+
+    helperStatus.className = 'mb-6 p-4 rounded-lg border bg-yellow-900/30 border-yellow-700';
+    helperStatus.innerHTML = `
+        <div class="flex items-center">
+            <svg class="w-5 h-5 mr-2 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+            </svg>
+            <div>
+                <p class="font-medium text-yellow-300">Helper Service Not Running</p>
+                <p class="text-sm text-yellow-200/70">Disk management requires the pihealth-helper service. Start it with: <code class="bg-gray-800 px-1 rounded">sudo systemctl start pihealth-helper</code></p>
+            </div>
+        </div>
+    `;
+    helperStatus.classList.remove('hidden');
+
+    setNodeContent('disk-list', createEmptyState({
+        title: 'Helper service required for disk information',
+        containerClass: 'text-center py-10',
+        titleClass: 'text-gray-500',
+    }));
+}
+
+function hideHelperStatus() {
+    const helperStatus = document.getElementById('helper-status');
+    if (helperStatus) {
+        helperStatus.classList.add('hidden');
+    }
+}
+
+async function loadDisks() {
+    setNodeContent('disk-list', createLoadingState({
+        message: 'Loading...',
+        containerClass: 'text-center py-10',
+        messageClass: 'text-gray-400',
+    }));
+
+    try {
+        const response = await apiFetch('/api/disks');
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+            throw new Error(data?.error || `Failed to load disks (${response.status})`);
+        }
+
+        if (!data.helper_available) {
+            renderHelperUnavailable();
+            return;
+        }
+
+        hideHelperStatus();
+        diskInventory = data.disks || [];
+
+        if (!diskInventory.length) {
+            setNodeContent('disk-list', createEmptyState({
+                title: 'No storage devices found',
+                containerClass: 'text-center py-10',
+                titleClass: 'text-gray-400',
+            }));
+            return;
+        }
+
+        renderDisks();
+        await loadSuggestions();
+    } catch (error) {
+        setNodeContent('disk-list', createErrorState({
+            title: `Error loading disks: ${error.message}`,
+            containerClass: 'text-center py-10',
+            titleClass: 'text-red-400',
+        }));
+    }
+}
+
+function renderDisks() {
+    const diskList = document.getElementById('disk-list');
+    if (!diskList) {
+        return;
+    }
+
+    const html = diskInventory.map((disk) => {
+        const hasPartitions = Array.isArray(disk.partitions) && disk.partitions.length > 0;
+        const displayItems = hasPartitions ? disk.partitions : [disk];
+
+        return `
+            <div class="disk-card bg-gray-800 rounded-lg border border-purple-900/40 overflow-hidden">
+                <div class="p-4 bg-gray-800/50 border-b border-gray-700">
+                    <div class="flex justify-between items-start">
+                        <div>
+                            <h4 class="font-semibold text-lg">${escapeHtml(disk.path)}</h4>
+                            <p class="text-sm text-gray-400">${escapeHtml(disk.model || 'Unknown device')} ${disk.serial ? `(${escapeHtml(disk.serial)})` : ''}</p>
+                        </div>
+                        <div class="text-right">
+                            <span class="text-lg font-medium">${escapeHtml(disk.size)}</span>
+                            <p class="text-xs text-gray-500">${escapeHtml(disk.transport || 'unknown')} ${disk.hotplug ? '(removable)' : ''}</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="divide-y divide-gray-700">
+                    ${displayItems.map((part) => renderPartition(part)).join('')}
+                </div>
+            </div>
+        `;
+    }).join('');
+
+    diskList.innerHTML = html;
+    bindDiskActions(diskList);
+}
+
+function renderPartition(part) {
+    const mounted = !!part.mounted;
+    const statusClass = mounted ? 'mounted' : 'unmounted';
+    const statusText = mounted ? 'Mounted' : 'Not Mounted';
+
+    let usageBar = '';
+    if (part.usage) {
+        const percent = parseInt(part.usage.percent, 10) || 0;
+        const colorClass = percent > 90 ? 'bg-red-500' : percent > 70 ? 'bg-yellow-500' : 'bg-green-500';
+        usageBar = `
+            <div class="mt-2">
+                <div class="flex justify-between text-xs text-gray-400 mb-1">
+                    <span>${formatBytes(part.usage.used)} used</span>
+                    <span>${formatBytes(part.usage.available)} free</span>
+                </div>
+                <div class="progress-bar">
+                    <div class="progress-fill ${colorClass}" style="width: ${percent}%"></div>
+                </div>
+            </div>
+        `;
+    }
+
+    let actions = '<span class="text-xs text-gray-500">No filesystem</span>';
+    if (mounted) {
+        actions = `
+            <button type="button"
+                    class="px-3 py-1 text-sm rounded bg-red-700 hover:bg-red-600 text-white js-unmount"
+                    data-mountpoint="${encodeDataAttr(part.mountpoint || '')}">
+                Unmount
+            </button>
+        `;
+    } else if (part.uuid) {
+        actions = `
+            <button type="button"
+                    class="coraline-button px-3 py-1 text-sm rounded text-white js-open-mount"
+                    data-device="${encodeDataAttr(part.path || '')}"
+                    data-uuid="${encodeDataAttr(part.uuid || '')}"
+                    data-fstype="${encodeDataAttr(part.fstype || 'ext4')}">
+                Mount
+            </button>
+        `;
+    }
+
+    return `
+        <div class="p-4">
+            <div class="flex justify-between items-start">
+                <div class="flex-1">
+                    <div class="flex items-center space-x-2">
+                        <span class="font-medium">${escapeHtml(part.path || part.name)}</span>
+                        <span class="text-xs px-2 py-0.5 rounded ${part.fstype ? 'bg-blue-900 text-blue-300' : 'bg-gray-700 text-gray-400'}">${escapeHtml(part.fstype || 'unknown')}</span>
+                        <span class="text-xs ${statusClass}">${statusText}</span>
+                    </div>
+                    ${part.mountpoint ? `<p class="text-sm text-gray-400 mt-1">Mounted at: ${escapeHtml(part.mountpoint)}</p>` : ''}
+                    ${part.uuid ? `<p class="text-xs text-gray-500 mt-1">UUID: ${escapeHtml(part.uuid)}</p>` : ''}
+                    ${usageBar}
+                </div>
+                <div class="ml-4 flex items-center space-x-2">
+                    <span class="text-sm text-gray-400">${escapeHtml(part.size)}</span>
+                    ${actions}
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+function bindDiskActions(diskList) {
+    diskList.querySelectorAll('.js-unmount').forEach((button) => {
+        button.addEventListener('click', async () => {
+            const mountpoint = button.dataset.mountpoint || '';
+            if (mountpoint) {
+                await unmountDisk(mountpoint);
+            }
+        });
+    });
+
+    diskList.querySelectorAll('.js-open-mount').forEach((button) => {
+        button.addEventListener('click', () => {
+            openMountModal(
+                button.dataset.device || '',
+                button.dataset.uuid || '',
+                button.dataset.fstype || 'ext4'
+            );
+        });
+    });
+}
+
+async function loadSuggestions() {
+    try {
+        const response = await apiFetch('/api/disks/suggested-mounts');
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data?.error || `Failed to load suggestions (${response.status})`);
+        }
+
+        const suggestions = data.suggestions || [];
+        const section = document.getElementById('suggestions-section');
+        const list = document.getElementById('suggestions-list');
+
+        if (!section || !list) {
+            return;
+        }
+
+        if (!suggestions.length) {
+            section.classList.add('hidden');
+            list.innerHTML = '';
+            return;
+        }
+
+        section.classList.remove('hidden');
+        list.innerHTML = suggestions.map((s) => `
+            <div class="bg-gray-800 rounded-lg p-4 border border-purple-900/40 flex justify-between items-center">
+                <div>
+                    <p class="font-medium">${escapeHtml(s.device)} <span class="text-gray-400">(${escapeHtml(s.size)})</span></p>
+                    <p class="text-sm text-gray-400">${escapeHtml(s.reason)}</p>
+                </div>
+                <button type="button"
+                        class="coraline-button px-3 py-1 text-sm rounded text-white js-open-suggested-mount"
+                        data-device="${encodeDataAttr(s.device)}"
+                        data-uuid="${encodeDataAttr(s.uuid)}"
+                        data-fstype="${encodeDataAttr(s.fstype)}"
+                        data-suggested-mount="${encodeDataAttr(s.suggested_mount)}">
+                    Mount as ${escapeHtml(s.suggested_mount)}
+                </button>
+            </div>
+        `).join('');
+
+        list.querySelectorAll('.js-open-suggested-mount').forEach((button) => {
+            button.addEventListener('click', () => {
+                openMountModal(
+                    button.dataset.device || '',
+                    button.dataset.uuid || '',
+                    button.dataset.fstype || 'ext4',
+                    button.dataset.suggestedMount || ''
+                );
+            });
+        });
+    } catch (error) {
+        console.error('Failed to load suggestions:', error);
+    }
+}
+
+function openMountModal(device, uuid, fstype, suggestedMount = '') {
+    currentMount = { device, uuid, fstype };
+    const modal = document.getElementById('mount-modal');
+    const mountDevice = document.getElementById('mount-device');
+    const mountUuid = document.getElementById('mount-uuid');
+    const mountFstype = document.getElementById('mount-fstype');
+    const mountPoint = document.getElementById('mount-point');
+
+    if (mountDevice) mountDevice.value = device;
+    if (mountUuid) mountUuid.value = uuid;
+    if (mountFstype) mountFstype.value = fstype;
+    if (mountPoint) mountPoint.value = suggestedMount || '/mnt/';
+
+    if (modal) {
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+    }
+}
+
+function closeMountModal() {
+    const modal = document.getElementById('mount-modal');
+    if (modal) {
+        modal.classList.add('hidden');
+        modal.classList.remove('flex');
+    }
+    currentMount = {};
+}
+
+async function submitMount() {
+    const mountpoint = document.getElementById('mount-point')?.value || '';
+    const addToFstab = document.getElementById('mount-fstab')?.checked || false;
+
+    if (!mountpoint || !mountpoint.startsWith('/mnt/')) {
+        showNotification('Mountpoint must start with /mnt/', 'error');
+        return;
+    }
+
+    try {
+        const response = await apiFetch('/api/disks/mount', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                uuid: currentMount.uuid,
+                mountpoint,
+                fstype: currentMount.fstype,
+                add_to_fstab: addToFstab,
+            }),
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data?.error || 'Mount failed');
+        }
+
+        showNotification(`Mounted at ${mountpoint}`, 'success');
+        closeMountModal();
+        await loadDisks();
+    } catch (error) {
+        showNotification(`Mount failed: ${error.message}`, 'error');
+    }
+}
+
+async function unmountDisk(mountpoint) {
+    if (!window.confirm(`Unmount ${mountpoint}? Make sure no applications are using this storage.`)) {
+        return;
+    }
+
+    try {
+        const response = await apiFetch('/api/disks/unmount', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                mountpoint,
+                remove_from_fstab: false,
+            }),
+        });
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data?.error || 'Unmount failed');
+        }
+
+        showNotification(`Unmounted ${mountpoint}`, 'success');
+        await loadDisks();
+    } catch (error) {
+        showNotification(`Unmount failed: ${error.message}`, 'error');
+    }
+}
+
+async function loadSmartData() {
+    const smartList = document.getElementById('smart-list');
+    if (!smartList) {
+        return;
+    }
+
+    smartList.innerHTML = '<div class="text-gray-400 text-sm">Loading SMART data...</div>';
+
+    try {
+        const response = await apiFetch('/api/disks/smart');
+        const data = await response.json().catch(() => ({}));
+
+        if (data.error) {
+            smartList.innerHTML = `<div class="text-red-400 text-sm">${escapeHtml(data.error)}</div>`;
+            return;
+        }
+
+        if (!response.ok) {
+            throw new Error(data?.error || `Failed to load SMART data (${response.status})`);
+        }
+
+        smartData = data.disks || [];
+
+        if (!smartData.length) {
+            smartList.innerHTML = '<div class="text-gray-400 text-sm">No SMART-capable devices found</div>';
+            return;
+        }
+
+        renderSmartCards();
+    } catch (error) {
+        smartList.innerHTML = `<div class="text-red-400 text-sm">Error: ${escapeHtml(error.message)}</div>`;
+    }
+}
+
+function renderSmartCards() {
+    const smartList = document.getElementById('smart-list');
+    if (!smartList) {
+        return;
+    }
+
+    smartList.innerHTML = smartData.map((disk) => {
+        const data = disk.data || {};
+        const device = disk.device || 'unknown';
+        const deviceName = device.replace('/dev/', '');
+        const status = data.health_status || 'unknown';
+        const statusClass = status === 'healthy'
+            ? 'healthy'
+            : status === 'warning'
+                ? 'warning'
+                : status === 'failing'
+                    ? 'failing'
+                    : 'unknown';
+
+        let powerOnDisplay = 'Unknown';
+        if (data.power_on_hours != null) {
+            const hours = data.power_on_hours;
+            const days = Math.floor(hours / 24);
+            const years = Math.floor(days / 365);
+            const remainingDays = days % 365;
+            powerOnDisplay = years > 0 ? `${years}y ${remainingDays}d` : days > 0 ? `${days}d` : `${hours}h`;
+        }
+
+        const driveIcon = data.drive_type === 'nvme'
+            ? '⚡'
+            : data.drive_type === 'ssd'
+                ? '💾'
+                : data.drive_type === 'hdd'
+                    ? '🗄️'
+                    : '💿';
+
+        return `
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-700 hover:border-purple-600 cursor-pointer transition-colors js-smart-card"
+                 data-device-name="${encodeDataAttr(deviceName)}">
+                <div class="flex justify-between items-start mb-3">
+                    <div class="flex items-center">
+                        <span class="text-2xl mr-2">${driveIcon}</span>
+                        <div>
+                            <h4 class="font-semibold">${escapeHtml(device)}</h4>
+                            <p class="text-xs text-gray-400">${escapeHtml(data.model || 'Unknown')}</p>
+                        </div>
+                    </div>
+                    <span class="smart-badge ${statusClass}">${escapeHtml(status.toUpperCase())}</span>
+                </div>
+                <div class="grid grid-cols-2 gap-2 text-sm">
+                    <div>
+                        <span class="text-gray-400">Temp:</span>
+                        <span class="${data.temperature_c > 55 ? 'text-yellow-400' : 'text-gray-200'}">${data.temperature_c != null ? `${data.temperature_c}°C` : 'N/A'}</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-400">Power On:</span>
+                        <span class="text-gray-200">${escapeHtml(powerOnDisplay)}</span>
+                    </div>
+                    ${data.drive_type === 'nvme' ? `
+                    <div>
+                        <span class="text-gray-400">Used:</span>
+                        <span class="${data.percentage_used > 90 ? 'text-red-400' : 'text-gray-200'}">${data.percentage_used != null ? `${data.percentage_used}%` : 'N/A'}</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-400">Spare:</span>
+                        <span class="${data.available_spare < 10 ? 'text-red-400' : 'text-gray-200'}">${data.available_spare != null ? `${data.available_spare}%` : 'N/A'}</span>
+                    </div>
+                    ` : `
+                    <div>
+                        <span class="text-gray-400">Realloc:</span>
+                        <span class="${data.reallocated_sectors > 0 ? 'text-yellow-400' : 'text-gray-200'}">${data.reallocated_sectors != null ? data.reallocated_sectors : 'N/A'}</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-400">Pending:</span>
+                        <span class="${data.pending_sectors > 0 ? 'text-yellow-400' : 'text-gray-200'}">${data.pending_sectors != null ? data.pending_sectors : 'N/A'}</span>
+                    </div>
+                    `}
+                </div>
+                ${data.error_message ? `<p class="mt-2 text-xs text-yellow-400">${escapeHtml(data.error_message)}</p>` : ''}
+            </div>
+        `;
+    }).join('');
+
+    smartList.querySelectorAll('.js-smart-card').forEach((card) => {
+        card.addEventListener('click', async () => {
+            const deviceName = card.dataset.deviceName || '';
+            if (deviceName) {
+                await openSmartModal(deviceName);
+            }
+        });
+    });
+}
+
+async function openSmartModal(deviceName) {
+    currentSmartDevice = deviceName;
+    const modal = document.getElementById('smart-modal');
+    const title = document.getElementById('smart-modal-title');
+    const content = document.getElementById('smart-modal-content');
+
+    if (title) {
+        title.textContent = `SMART Details - /dev/${deviceName}`;
+    }
+    if (content) {
+        content.innerHTML = '<div class="text-gray-400">Loading detailed SMART data...</div>';
+    }
+
+    if (modal) {
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+    }
+
+    try {
+        const response = await apiFetch(`/api/disks/${encodeURIComponent(deviceName)}/smart`);
+        const data = await response.json().catch(() => ({}));
+
+        if (data.error) {
+            if (content) {
+                content.innerHTML = `<div class="text-red-400">${escapeHtml(data.error)}</div>`;
+            }
+            return;
+        }
+
+        if (!response.ok) {
+            throw new Error(data?.error || `Failed to load SMART details (${response.status})`);
+        }
+
+        renderSmartDetails(data);
+    } catch (error) {
+        if (content) {
+            content.innerHTML = `<div class="text-red-400">Error: ${escapeHtml(error.message)}</div>`;
+        }
+    }
+}
+
+function renderSmartDetails(data) {
+    const content = document.getElementById('smart-modal-content');
+    if (!content) {
+        return;
+    }
+
+    const status = data.health_status || 'unknown';
+    const statusClass = status === 'healthy'
+        ? 'healthy'
+        : status === 'warning'
+            ? 'warning'
+            : status === 'failing'
+                ? 'failing'
+                : 'unknown';
+
+    let html = `
+        <div class="mb-6">
+            <div class="flex items-center justify-between mb-4">
+                <div>
+                    <h4 class="font-semibold text-lg">${escapeHtml(data.model || 'Unknown Model')}</h4>
+                    <p class="text-sm text-gray-400">Serial: ${escapeHtml(data.serial || 'Unknown')}</p>
+                </div>
+                <span class="smart-badge ${statusClass}">${escapeHtml(status.toUpperCase())}</span>
+            </div>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                <div class="bg-gray-800 p-3 rounded">
+                    <span class="text-gray-400 block">Type</span>
+                    <span class="font-medium">${escapeHtml((data.drive_type || 'unknown').toUpperCase())}</span>
+                </div>
+                <div class="bg-gray-800 p-3 rounded">
+                    <span class="text-gray-400 block">Temperature</span>
+                    <span class="font-medium ${data.temperature_c > 55 ? 'text-yellow-400' : ''}">${data.temperature_c != null ? `${data.temperature_c}°C` : 'N/A'}</span>
+                </div>
+                <div class="bg-gray-800 p-3 rounded">
+                    <span class="text-gray-400 block">Power On Hours</span>
+                    <span class="font-medium">${data.power_on_hours != null ? Number(data.power_on_hours).toLocaleString() : 'N/A'}</span>
+                </div>
+                <div class="bg-gray-800 p-3 rounded">
+                    <span class="text-gray-400 block">SMART</span>
+                    <span class="font-medium">${data.smart_enabled ? 'Enabled' : data.smart_available ? 'Available' : 'N/A'}</span>
+                </div>
+            </div>
+        </div>
+    `;
+
+    if (data.error_message) {
+        html += `
+            <div class="mb-4 p-3 bg-yellow-900/30 border border-yellow-700 rounded text-yellow-300 text-sm">
+                <strong>Warning:</strong> ${escapeHtml(data.error_message)}
+            </div>
+        `;
+    }
+
+    if (Array.isArray(data.attributes) && data.attributes.length > 0) {
+        html += `
+            <div>
+                <h5 class="font-semibold mb-2">SMART Attributes</h5>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="text-gray-400 border-b border-gray-700">
+                                ${data.drive_type === 'nvme' ? `
+                                    <th class="text-left py-2 px-2">Attribute</th>
+                                    <th class="text-right py-2 px-2">Value</th>
+                                ` : `
+                                    <th class="text-left py-2 px-1">ID</th>
+                                    <th class="text-left py-2 px-2">Attribute</th>
+                                    <th class="text-right py-2 px-2">Value</th>
+                                    <th class="text-right py-2 px-2">Worst</th>
+                                    <th class="text-right py-2 px-2">Thresh</th>
+                                    <th class="text-right py-2 px-2">Raw</th>
+                                `}
+                            </tr>
+                        </thead>
+                        <tbody>
+        `;
+
+        for (const attr of data.attributes) {
+            const critical = attr.critical ? 'smart-attr-critical' : '';
+            if (data.drive_type === 'nvme') {
+                html += `
+                    <tr class="border-b border-gray-800 smart-attr-row ${critical}">
+                        <td class="py-2 px-2">${escapeHtml(attr.name)}</td>
+                        <td class="py-2 px-2 text-right font-mono">${attr.value != null ? Number(attr.value).toLocaleString() : 'N/A'}</td>
+                    </tr>
+                `;
+            } else {
+                html += `
+                    <tr class="border-b border-gray-800 smart-attr-row ${critical}">
+                        <td class="py-2 px-1 text-gray-500">${attr.id || ''}</td>
+                        <td class="py-2 px-2">${escapeHtml(attr.name)}</td>
+                        <td class="py-2 px-2 text-right font-mono">${attr.value != null ? attr.value : ''}</td>
+                        <td class="py-2 px-2 text-right font-mono text-gray-500">${attr.worst != null ? attr.worst : ''}</td>
+                        <td class="py-2 px-2 text-right font-mono text-gray-500">${attr.thresh != null ? attr.thresh : ''}</td>
+                        <td class="py-2 px-2 text-right font-mono ${attr.critical && attr.raw > 0 ? 'text-yellow-400' : ''}">${attr.raw != null ? Number(attr.raw).toLocaleString() : ''}</td>
+                    </tr>
+                `;
+            }
+        }
+
+        html += `
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        `;
+    }
+
+    content.innerHTML = html;
+}
+
+function closeSmartModal() {
+    const modal = document.getElementById('smart-modal');
+    if (modal) {
+        modal.classList.add('hidden');
+        modal.classList.remove('flex');
+    }
+    currentSmartDevice = null;
+}
+
+async function runSmartTest(testType) {
+    if (!currentSmartDevice) {
+        return;
+    }
+
+    const confirmation = testType === 'long'
+        ? `Run a ${testType} SMART self-test on /dev/${currentSmartDevice}? This may take several hours.`
+        : `Run a ${testType} SMART self-test on /dev/${currentSmartDevice}? This typically takes 1-2 minutes.`;
+
+    if (!window.confirm(confirmation)) {
+        return;
+    }
+
+    try {
+        const response = await apiFetch(`/api/disks/${encodeURIComponent(currentSmartDevice)}/smart-test`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ test_type: testType }),
+        });
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+            throw new Error(data?.error || 'Failed to start test');
+        }
+
+        showNotification(`${testType.charAt(0).toUpperCase() + testType.slice(1)} SMART test started on /dev/${currentSmartDevice}`, 'success');
+    } catch (error) {
+        showNotification(`Error: ${error.message}`, 'error');
+    }
+}
+
+Object.assign(window, {
+    loadDisks,
+    loadSmartData,
+    closeMountModal,
+    submitMount,
+    closeSmartModal,
+    runSmartTest,
+});
+
+(async function initDisksPage() {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+        return;
+    }
+
+    window.logout = logoutToLogin;
+    await loadDisks();
+})();


### PR DESCRIPTION
## Summary
- migrate static/disks.html to modular page structure and remove inline auth/style/script blocks
- add static/css/disks.css for page-specific styles
- add static/js/pages/disks.js with shared auth/layout bootstrap and 401 handling
- preserve disk inventory, mount/unmount, suggestions, and SMART detail/test behavior
- harden dynamic disk/suggestion/smart card actions by using data attributes with bound listeners
- update Docs/UI_MIGRATION_TRACKER.md to mark disks as migrated and split remaining pages

## Validation
- node --check static/js/pages/disks.js
- pytest -q tests/test_disk_manager.py::TestDisksPage::test_disks_page_loads
- pytest -q tests/test_app.py::TestStaticPages
- tox -e all (via commit hook)
