### PR TITLE
Migrate tailscale page to modular JS/CSS

### DIFF
--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -58,7 +58,7 @@
 - [x] Migrate `plugins`.
 - [x] Migrate `disks`.
 - [x] Migrate `network`.
-- [ ] Migrate `tailscale`.
+- [x] Migrate `tailscale`.
 - [ ] Migrate `tools`.
 - [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
 - [ ] Validate plugin-specific edge cases.

--- a/static/css/tailscale.css
+++ b/static/css/tailscale.css
@@ -1,0 +1,63 @@
+.coraline-button {
+    background: linear-gradient(to bottom, #5f4b8b, #372b53);
+    border: 1px solid #8a6cbd;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
+    transition: all 0.3s ease;
+}
+
+.coraline-button:hover:not(:disabled) {
+    background: linear-gradient(to bottom, #6f58a3, #413162);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
+}
+
+.coraline-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.status-pill {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.status-connected {
+    background-color: rgba(52, 211, 153, 0.2);
+    color: #34d399;
+    border: 1px solid #34d399;
+}
+
+.status-disconnected {
+    background-color: rgba(248, 113, 113, 0.2);
+    color: #f87171;
+    border: 1px solid #f87171;
+}
+
+.status-not-installed {
+    background-color: rgba(156, 163, 175, 0.2);
+    color: #9ca3af;
+    border: 1px solid #9ca3af;
+}
+
+.info-card {
+    background-color: rgba(17, 24, 39, 0.5);
+    border: 1px solid rgba(107, 33, 168, 0.3);
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.info-label {
+    color: #9ca3af;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.info-value {
+    color: #e5e7eb;
+    font-size: 1rem;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+}

--- a/static/js/pages/tailscale.js
+++ b/static/js/pages/tailscale.js
@@ -1,0 +1,252 @@
+import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearClientSession } from '/js/lib/session.js';
+
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
+    includeFooter: true,
+});
+
+let currentStatus = null;
+
+async function apiFetch(url, options = {}) {
+    const response = await fetch(url, options);
+    if (response.status === 401) {
+        clearClientSession();
+        window.location.href = '/login.html';
+        throw new Error('Authentication required');
+    }
+    return response;
+}
+
+function escapeHtml(text) {
+    if (!text) return '';
+    return String(text)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function formatBytes(bytes) {
+    if (!bytes || bytes <= 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+function setLoadingState(isLoading, message = '') {
+    const loadingState = document.getElementById('loading-state');
+    if (!loadingState) {
+        return;
+    }
+
+    if (isLoading) {
+        loadingState.classList.remove('hidden');
+        loadingState.innerHTML = `
+            <svg class="animate-spin h-8 w-8 mx-auto mb-4 text-purple-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            ${message || 'Loading Tailscale status...'}
+        `;
+    } else {
+        loadingState.classList.add('hidden');
+    }
+}
+
+function setLoadError(message) {
+    const loadingState = document.getElementById('loading-state');
+    if (!loadingState) {
+        return;
+    }
+    loadingState.classList.remove('hidden');
+    loadingState.innerHTML = `<p class="text-red-400">Failed to load Tailscale status: ${escapeHtml(message)}</p>`;
+}
+
+function showSetupSection(status) {
+    const setupSection = document.getElementById('setup-section');
+    const statusSection = document.getElementById('status-section');
+    const setupStatus = document.getElementById('setup-status');
+
+    if (setupSection) setupSection.classList.remove('hidden');
+    if (statusSection) statusSection.classList.add('hidden');
+    if (setupStatus) setupStatus.textContent = status;
+}
+
+function showStatusSection(data) {
+    const setupSection = document.getElementById('setup-section');
+    const statusSection = document.getElementById('status-section');
+    if (setupSection) setupSection.classList.add('hidden');
+    if (statusSection) statusSection.classList.remove('hidden');
+
+    const statusEl = document.getElementById('connection-status');
+    if (statusEl) {
+        if (data.online) {
+            statusEl.textContent = 'Online';
+            statusEl.className = 'status-pill status-connected';
+        } else {
+            statusEl.textContent = 'Offline';
+            statusEl.className = 'status-pill status-disconnected';
+        }
+    }
+
+    const ips = data.tailscale_ips || [];
+    const firstIp = ips[0] || '-';
+
+    const setText = (id, value) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = value;
+    };
+
+    setText('ts-ip', firstIp);
+    setText('ts-hostname', data.hostname || '-');
+    setText('ts-dns', data.dns_name || '-');
+    setText('ts-tailnet', data.tailnet_name || '-');
+    setText('ts-state', data.backend_state || '-');
+    setText('ts-peers', data.peers !== undefined ? String(data.peers) : '-');
+    setText('ts-relay', data.relay || 'Direct');
+
+    const rx = formatBytes(data.rx_bytes || 0);
+    const tx = formatBytes(data.tx_bytes || 0);
+    setText('ts-traffic', `${rx} / ${tx}`);
+
+    const accessUrl = data.dns_name ? String(data.dns_name).replace(/\.$/, '') : firstIp;
+    setText('access-url', accessUrl);
+
+    const health = data.health || [];
+    const healthSection = document.getElementById('health-warnings');
+    const healthList = document.getElementById('health-list');
+
+    if (healthSection && healthList) {
+        if (health.length > 0) {
+            healthSection.classList.remove('hidden');
+            healthList.innerHTML = health.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+        } else {
+            healthSection.classList.add('hidden');
+            healthList.innerHTML = '';
+        }
+    }
+}
+
+async function loadStatus() {
+    try {
+        const response = await apiFetch('/api/tailscale/status');
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+            throw new Error(data?.error || `Request failed (${response.status})`);
+        }
+
+        setLoadingState(false);
+        currentStatus = data;
+
+        if (!data.installed) {
+            showSetupSection('Not Installed');
+        } else if (!data.running) {
+            showSetupSection('Not Running');
+        } else {
+            showStatusSection(data);
+        }
+    } catch (error) {
+        setLoadError(error.message || 'Unknown error');
+    }
+}
+
+function showNotification(message, type = 'info') {
+    const area = document.getElementById('notification-area');
+    if (!area) {
+        return;
+    }
+
+    const colors = {
+        success: 'bg-green-800 border-green-600',
+        error: 'bg-red-800 border-red-600',
+        info: 'bg-blue-800 border-blue-600',
+    };
+
+    const notification = document.createElement('div');
+    notification.className = `${colors[type] || colors.info} border rounded-lg p-4 shadow-lg transition-opacity duration-500`;
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'text-white text-sm';
+    messageEl.textContent = message;
+    notification.appendChild(messageEl);
+
+    area.appendChild(notification);
+    setTimeout(() => {
+        notification.classList.add('opacity-0');
+        setTimeout(() => notification.remove(), 500);
+    }, 5000);
+}
+
+async function setupTailscale() {
+    const authKey = document.getElementById('tailscale-authkey')?.value.trim() || '';
+
+    showNotification('Installing and configuring Tailscale...', 'info');
+
+    try {
+        const response = await apiFetch('/api/setup/tailscale', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ auth_key: authKey }),
+        });
+
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data?.error || 'Setup failed');
+        }
+
+        showNotification('Tailscale setup complete!', 'success');
+        setTimeout(() => loadStatus(), 2000);
+    } catch (error) {
+        showNotification(`Error: ${error.message}`, 'error');
+    }
+}
+
+async function reauthenticate() {
+    if (!window.confirm('This will log out of Tailscale. You will need to re-authenticate. Continue?')) {
+        return;
+    }
+
+    try {
+        const response = await apiFetch('/api/tailscale/logout', { method: 'POST' });
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+            throw new Error(data?.error || 'Logout failed');
+        }
+
+        showNotification('Logged out. Please set up Tailscale again.', 'info');
+        await loadStatus();
+    } catch (error) {
+        showNotification(`Error: ${error.message}`, 'error');
+    }
+}
+
+function refreshStatus() {
+    setLoadingState(true, 'Loading Tailscale status...');
+    const statusSection = document.getElementById('status-section');
+    const setupSection = document.getElementById('setup-section');
+    if (statusSection) statusSection.classList.add('hidden');
+    if (setupSection) setupSection.classList.add('hidden');
+    loadStatus();
+}
+
+Object.assign(window, {
+    setupTailscale,
+    reauthenticate,
+    refreshStatus,
+});
+
+(async function initTailscalePage() {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+        return;
+    }
+
+    window.logout = logoutToLogin;
+    await loadStatus();
+})();

--- a/static/tailscale.html
+++ b/static/tailscale.html
@@ -1,79 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        if (!sessionStorage.getItem("loggedIn")) {
-            window.location.href = "/login.html";
-        }
-
-        const username = sessionStorage.getItem("username");
-        if (username) {
-            document.addEventListener('DOMContentLoaded', () => {
-                const userEl = document.getElementById('logged-in-user');
-                if (userEl) userEl.textContent = username;
-            });
-        }
-
-        async function logout() {
-            try {
-                await fetch('/api/logout', { method: 'POST' });
-            } catch (e) {}
-            sessionStorage.clear();
-            window.location.href = '/login.html';
-        }
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tailscale - Pi-Health Dashboard</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="stylesheet" href="/css/foundation.css">
+    <link rel="stylesheet" href="/css/tailscale.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
-    <style>
-        .coraline-button {
-            background: linear-gradient(to bottom, #5f4b8b, #372b53);
-            border: 1px solid #8a6cbd;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
-            transition: all 0.3s ease;
-        }
-        .coraline-button:hover:not(:disabled) {
-            background: linear-gradient(to bottom, #6f58a3, #413162);
-            transform: translateY(-2px);
-            box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
-        }
-        .coraline-button:disabled {
-            opacity: 0.5;
-            cursor: not-allowed;
-        }
-        .status-pill {
-            display: inline-block;
-            padding: 0.25rem 0.75rem;
-            border-radius: 9999px;
-            font-size: 0.75rem;
-            font-weight: 500;
-        }
-        .status-connected { background-color: rgba(52, 211, 153, 0.2); color: #34d399; border: 1px solid #34d399; }
-        .status-disconnected { background-color: rgba(248, 113, 113, 0.2); color: #f87171; border: 1px solid #f87171; }
-        .status-not-installed { background-color: rgba(156, 163, 175, 0.2); color: #9ca3af; border: 1px solid #9ca3af; }
-        .info-card {
-            background-color: rgba(17, 24, 39, 0.5);
-            border: 1px solid rgba(107, 33, 168, 0.3);
-            border-radius: 0.5rem;
-            padding: 1rem;
-        }
-        .info-label {
-            color: #9ca3af;
-            font-size: 0.75rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-        .info-value {
-            color: #e5e7eb;
-            font-size: 1rem;
-            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-        }
-    </style>
 </head>
 <body class="bg-gray-900 text-blue-100 font-sans min-h-screen">
     <header class="bg-gradient-to-r from-purple-900 to-blue-900 shadow-lg relative overflow-hidden">
@@ -84,7 +21,6 @@
         </div>
     </header>
 
-    <!-- Navigation bar -->
     <nav id="main-nav" class="bg-purple-900 shadow-md"></nav>
 
     <div id="notification-area" class="fixed top-4 right-4 z-50 w-80 flex flex-col items-end"></div>
@@ -95,7 +31,6 @@
             <p class="text-sm text-gray-400 mt-1">Secure remote access via Tailscale VPN.</p>
         </div>
 
-        <!-- Loading State -->
         <div id="loading-state" class="text-center py-10 text-gray-400">
             <svg class="animate-spin h-8 w-8 mx-auto mb-4 text-purple-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -104,7 +39,6 @@
             Loading Tailscale status...
         </div>
 
-        <!-- Not Installed / Setup Section -->
         <section id="setup-section" class="hidden">
             <div class="bg-gray-800 border border-purple-900/40 rounded-lg p-6">
                 <div class="flex items-center gap-3 mb-4">
@@ -136,7 +70,6 @@
             </div>
         </section>
 
-        <!-- Connected Status Section -->
         <section id="status-section" class="hidden">
             <div class="bg-gray-800 border border-purple-900/40 rounded-lg p-6 mb-6">
                 <div class="flex items-center justify-between mb-6">
@@ -159,7 +92,6 @@
                     </div>
                 </div>
 
-                <!-- Network Info Grid -->
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                     <div class="info-card">
                         <div class="info-label">Tailscale IP</div>
@@ -187,7 +119,6 @@
                     </div>
                 </div>
 
-                <!-- Additional Info -->
                 <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div class="info-card">
                         <div class="info-label">Traffic (RX / TX)</div>
@@ -199,14 +130,12 @@
                     </div>
                 </div>
 
-                <!-- Health Warnings -->
                 <div id="health-warnings" class="hidden mt-4 p-4 bg-yellow-900/20 border border-yellow-800 rounded-lg">
                     <h4 class="text-yellow-300 font-medium mb-2">Health Warnings</h4>
                     <ul id="health-list" class="text-sm text-yellow-200 list-disc list-inside"></ul>
                 </div>
             </div>
 
-            <!-- Quick Access Info -->
             <div class="bg-gray-800 border border-purple-900/40 rounded-lg p-6">
                 <h3 class="text-lg font-semibold mb-4">Quick Access</h3>
                 <p class="text-gray-400 text-sm mb-4">
@@ -219,166 +148,6 @@
         </section>
     </main>
 
-    <script>
-        let currentStatus = null;
-
-        async function loadStatus() {
-            try {
-                const response = await apiFetch('/api/tailscale/status');
-                const data = await response.json();
-
-                document.getElementById('loading-state').classList.add('hidden');
-                currentStatus = data;
-
-                if (!data.installed) {
-                    showSetupSection('Not Installed');
-                } else if (!data.running) {
-                    showSetupSection('Not Running');
-                } else {
-                    showStatusSection(data);
-                }
-            } catch (error) {
-                document.getElementById('loading-state').innerHTML =
-                    `<p class="text-red-400">Failed to load Tailscale status: ${error.message}</p>`;
-            }
-        }
-
-        function showSetupSection(status) {
-            document.getElementById('setup-section').classList.remove('hidden');
-            document.getElementById('status-section').classList.add('hidden');
-            document.getElementById('setup-status').textContent = status;
-        }
-
-        function showStatusSection(data) {
-            document.getElementById('setup-section').classList.add('hidden');
-            document.getElementById('status-section').classList.remove('hidden');
-
-            // Update connection status
-            const statusEl = document.getElementById('connection-status');
-            if (data.online) {
-                statusEl.textContent = 'Online';
-                statusEl.className = 'status-pill status-connected';
-            } else {
-                statusEl.textContent = 'Offline';
-                statusEl.className = 'status-pill status-disconnected';
-            }
-
-            // Update info cards
-            const ips = data.tailscale_ips || [];
-            document.getElementById('ts-ip').textContent = ips[0] || '-';
-            document.getElementById('ts-hostname').textContent = data.hostname || '-';
-            document.getElementById('ts-dns').textContent = data.dns_name || '-';
-            document.getElementById('ts-tailnet').textContent = data.tailnet_name || '-';
-            document.getElementById('ts-state').textContent = data.backend_state || '-';
-            document.getElementById('ts-peers').textContent = data.peers !== undefined ? data.peers : '-';
-            document.getElementById('ts-relay').textContent = data.relay || 'Direct';
-
-            // Format traffic
-            const rx = formatBytes(data.rx_bytes || 0);
-            const tx = formatBytes(data.tx_bytes || 0);
-            document.getElementById('ts-traffic').textContent = `${rx} / ${tx}`;
-
-            // Quick access URL
-            const accessUrl = data.dns_name ? data.dns_name.replace(/\.$/, '') : (ips[0] || '-');
-            document.getElementById('access-url').textContent = accessUrl;
-
-            // Health warnings
-            const health = data.health || [];
-            const healthSection = document.getElementById('health-warnings');
-            const healthList = document.getElementById('health-list');
-            if (health.length > 0) {
-                healthSection.classList.remove('hidden');
-                healthList.innerHTML = health.map(h => `<li>${escapeHtml(h)}</li>`).join('');
-            } else {
-                healthSection.classList.add('hidden');
-            }
-        }
-
-        function formatBytes(bytes) {
-            if (bytes === 0) return '0 B';
-            const k = 1024;
-            const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-            const i = Math.floor(Math.log(bytes) / Math.log(k));
-            return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
-        }
-
-        function escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
-        }
-
-        async function setupTailscale() {
-            const authKey = document.getElementById('tailscale-authkey').value.trim();
-
-            showNotification('Installing and configuring Tailscale...', 'info');
-
-            try {
-                const response = await apiFetch('/api/setup/tailscale', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ auth_key: authKey })
-                });
-
-                const data = await response.json();
-                if (!response.ok) {
-                    throw new Error(data.error || 'Setup failed');
-                }
-
-                showNotification('Tailscale setup complete!', 'success');
-                setTimeout(() => loadStatus(), 2000);
-            } catch (error) {
-                showNotification(`Error: ${error.message}`, 'error');
-            }
-        }
-
-        async function reauthenticate() {
-            if (!confirm('This will log out of Tailscale. You will need to re-authenticate. Continue?')) {
-                return;
-            }
-
-            try {
-                const response = await apiFetch('/api/tailscale/logout', { method: 'POST' });
-                const data = await response.json();
-
-                if (!response.ok) {
-                    throw new Error(data.error || 'Logout failed');
-                }
-
-                showNotification('Logged out. Please set up Tailscale again.', 'info');
-                loadStatus();
-            } catch (error) {
-                showNotification(`Error: ${error.message}`, 'error');
-            }
-        }
-
-        function refreshStatus() {
-            document.getElementById('loading-state').classList.remove('hidden');
-            document.getElementById('status-section').classList.add('hidden');
-            loadStatus();
-        }
-
-        function showNotification(message, type = 'info') {
-            const area = document.getElementById('notification-area');
-            const colors = {
-                success: 'bg-green-800 border-green-600',
-                error: 'bg-red-800 border-red-600',
-                info: 'bg-blue-800 border-blue-600'
-            };
-
-            const notification = document.createElement('div');
-            notification.className = `${colors[type] || colors.info} border rounded-lg p-4 shadow-lg transition-opacity duration-500`;
-            notification.innerHTML = `<p class="text-white text-sm">${escapeHtml(message)}</p>`;
-            area.appendChild(notification);
-
-            setTimeout(() => {
-                notification.classList.add('opacity-0');
-                setTimeout(() => notification.remove(), 500);
-            }, 5000);
-        }
-
-        // Load status on page load
-        document.addEventListener('DOMContentLoaded', loadStatus);
-    </script>
+    <script type="module" src="/js/pages/tailscale.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- migrate static/tailscale.html to modular page structure and remove inline auth/style/script blocks
- add static/css/tailscale.css for page styles
- add static/js/pages/tailscale.js with shared auth/layout bootstrap and 401 handling
- preserve setup and status sections, tailscale setup/logout actions, and load/error behavior
- update Docs/UI_MIGRATION_TRACKER.md to mark tailscale migrated

## Validation
- node --check static/js/pages/tailscale.js
- pytest -q tests/test_app.py::TestStaticPages::test_tailscale_page
- pytest -q tests/test_app.py::TestStaticPages
- tox -e all (via commit hook)
