### PR TITLE
Migrate tools page to modular JS/CSS

### DIFF
--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -59,7 +59,7 @@
 - [x] Migrate `disks`.
 - [x] Migrate `network`.
 - [x] Migrate `tailscale`.
-- [ ] Migrate `tools`.
+- [x] Migrate `tools`.
 - [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
 - [ ] Validate plugin-specific edge cases.
 

--- a/static/css/tools.css
+++ b/static/css/tools.css
@@ -1,0 +1,43 @@
+.coraline-button {
+    background: linear-gradient(to bottom, #5f4b8b, #372b53);
+    border: 1px solid #8a6cbd;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
+    transition: all 0.3s ease;
+}
+
+.coraline-button:hover:not(:disabled) {
+    background: linear-gradient(to bottom, #6f58a3, #413162);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
+}
+
+.coraline-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.status-pill {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.status-healthy {
+    background-color: rgba(52, 211, 153, 0.2);
+    color: #34d399;
+    border: 1px solid #34d399;
+}
+
+.status-degraded {
+    background-color: rgba(251, 191, 36, 0.2);
+    color: #fbbf24;
+    border: 1px solid #fbbf24;
+}
+
+.status-unconfigured {
+    background-color: rgba(156, 163, 175, 0.2);
+    color: #9ca3af;
+    border: 1px solid #9ca3af;
+}

--- a/static/js/pages/tools.js
+++ b/static/js/pages/tools.js
@@ -1,0 +1,136 @@
+import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearClientSession } from '/js/lib/session.js';
+
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
+    includeFooter: true,
+});
+
+async function apiFetch(url, options = {}) {
+    const response = await fetch(url, options);
+    if (response.status === 401) {
+        clearClientSession();
+        window.location.href = '/login.html';
+        throw new Error('Authentication required');
+    }
+    return response;
+}
+
+function statusPill(status) {
+    if (status === 'active') return 'status-healthy';
+    if (status === 'inactive') return 'status-degraded';
+    return 'status-unconfigured';
+}
+
+function showNotification(message, type = 'info') {
+    const notificationArea = document.getElementById('notification-area');
+    if (!notificationArea) {
+        return;
+    }
+
+    const notification = document.createElement('div');
+    notification.className = `mb-3 p-4 rounded shadow-lg text-white max-w-sm ${
+        type === 'error' ? 'bg-red-600' :
+        type === 'success' ? 'bg-green-600' : 'bg-blue-600'
+    }`;
+    notification.textContent = message;
+    notificationArea.appendChild(notification);
+    setTimeout(() => notification.remove(), 4000);
+}
+
+async function loadCopyParty() {
+    try {
+        const res = await apiFetch('/api/tools/copyparty/status');
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || 'Failed to load');
+        }
+
+        const sharePath = document.getElementById('copyparty-share-path');
+        const portInput = document.getElementById('copyparty-port');
+        const extraArgs = document.getElementById('copyparty-extra-args');
+        const serviceStatus = document.getElementById('copyparty-service-status');
+        const installedStatus = document.getElementById('copyparty-installed');
+        const statusPillEl = document.getElementById('copyparty-status-pill');
+        const link = document.getElementById('copyparty-link');
+
+        if (sharePath) sharePath.value = data.config?.share_path || '/srv/copyparty';
+        if (portInput) portInput.value = data.config?.port || 3923;
+        if (extraArgs) extraArgs.value = data.config?.extra_args || '';
+
+        if (serviceStatus) serviceStatus.textContent = data.service_status || 'unknown';
+        if (installedStatus) installedStatus.textContent = data.installed ? 'Yes' : 'No';
+
+        if (statusPillEl) {
+            statusPillEl.className = `status-pill ${statusPill(data.service_status)}`;
+            statusPillEl.textContent = data.service_status || 'unknown';
+        }
+
+        if (link) {
+            link.href = data.url || '#';
+            link.classList.toggle('opacity-50', !data.installed);
+            link.classList.toggle('pointer-events-none', !data.installed);
+        }
+    } catch (error) {
+        showNotification(`CopyParty error: ${error.message}`, 'error');
+    }
+}
+
+async function installCopyParty() {
+    try {
+        const res = await apiFetch('/api/tools/copyparty/install', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || 'Install failed');
+        }
+
+        showNotification('CopyParty installed', 'success');
+        await loadCopyParty();
+    } catch (error) {
+        showNotification(`Install failed: ${error.message}`, 'error');
+    }
+}
+
+async function saveCopyPartyConfig() {
+    const payload = {
+        share_path: document.getElementById('copyparty-share-path')?.value.trim() || '',
+        port: parseInt(document.getElementById('copyparty-port')?.value || '', 10),
+        extra_args: document.getElementById('copyparty-extra-args')?.value.trim() || '',
+    };
+
+    try {
+        const res = await apiFetch('/api/tools/copyparty/config', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || 'Save failed');
+        }
+
+        showNotification('CopyParty configuration saved', 'success');
+        await loadCopyParty();
+    } catch (error) {
+        showNotification(`Save failed: ${error.message}`, 'error');
+    }
+}
+
+Object.assign(window, {
+    installCopyParty,
+    saveCopyPartyConfig,
+});
+
+(async function initToolsPage() {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) {
+        return;
+    }
+
+    window.logout = logoutToLogin;
+    await loadCopyParty();
+})();

--- a/static/tools.html
+++ b/static/tools.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tools - Pi-Health Dashboard</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="/css/styles.css">
-    <script src="/js/auth.js"></script>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="stylesheet" href="/css/foundation.css">
+    <link rel="stylesheet" href="/css/tools.css">
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>
@@ -78,103 +80,6 @@
         </div>
     </main>
 
-    <script>
-        function showNotification(message, type = 'info') {
-            const notificationArea = document.getElementById('notification-area') || (() => {
-                const area = document.createElement('div');
-                area.id = 'notification-area';
-                area.className = 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end';
-                document.body.appendChild(area);
-                return area;
-            })();
-
-            const notification = document.createElement('div');
-            notification.className = `mb-3 p-4 rounded shadow-lg text-white max-w-sm ${
-                type === 'error' ? 'bg-red-600' :
-                type === 'success' ? 'bg-green-600' : 'bg-blue-600'
-            }`;
-            notification.textContent = message;
-            notificationArea.appendChild(notification);
-            setTimeout(() => notification.remove(), 4000);
-        }
-
-        function statusPill(status) {
-            if (status === 'active') return 'status-healthy';
-            if (status === 'inactive') return 'status-degraded';
-            return 'status-unconfigured';
-        }
-
-        async function loadCopyParty() {
-            try {
-                const res = await fetch('/api/tools/copyparty/status');
-                const data = await res.json();
-                if (!res.ok) {
-                    throw new Error(data.error || 'Failed to load');
-                }
-
-                document.getElementById('copyparty-share-path').value = data.config.share_path || '/srv/copyparty';
-                document.getElementById('copyparty-port').value = data.config.port || 3923;
-                document.getElementById('copyparty-extra-args').value = data.config.extra_args || '';
-
-                document.getElementById('copyparty-service-status').textContent = data.service_status || 'unknown';
-                document.getElementById('copyparty-installed').textContent = data.installed ? 'Yes' : 'No';
-
-                const pill = document.getElementById('copyparty-status-pill');
-                pill.className = `status-pill ${statusPill(data.service_status)}`;
-                pill.textContent = data.service_status || 'unknown';
-
-                const link = document.getElementById('copyparty-link');
-                link.href = data.url || '#';
-                link.classList.toggle('opacity-50', !data.installed);
-                link.classList.toggle('pointer-events-none', !data.installed);
-            } catch (e) {
-                showNotification(`CopyParty error: ${e.message}`, 'error');
-            }
-        }
-
-        async function installCopyParty() {
-            try {
-                const res = await fetch('/api/tools/copyparty/install', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' }
-                });
-                const data = await res.json();
-                if (!res.ok) {
-                    throw new Error(data.error || 'Install failed');
-                }
-                showNotification('CopyParty installed', 'success');
-                await loadCopyParty();
-            } catch (e) {
-                showNotification(`Install failed: ${e.message}`, 'error');
-            }
-        }
-
-        async function saveCopyPartyConfig() {
-            const payload = {
-                share_path: document.getElementById('copyparty-share-path').value.trim(),
-                port: parseInt(document.getElementById('copyparty-port').value, 10),
-                extra_args: document.getElementById('copyparty-extra-args').value.trim()
-            };
-            try {
-                const res = await fetch('/api/tools/copyparty/config', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(payload)
-                });
-                const data = await res.json();
-                if (!res.ok) {
-                    throw new Error(data.error || 'Save failed');
-                }
-                showNotification('CopyParty configuration saved', 'success');
-                await loadCopyParty();
-            } catch (e) {
-                showNotification(`Save failed: ${e.message}`, 'error');
-            }
-        }
-
-        document.addEventListener('DOMContentLoaded', () => {
-            loadCopyParty();
-        });
-    </script>
+    <script type="module" src="/js/pages/tools.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- migrate static/tools.html to modular page structure and remove inline script blocks
- add static/css/tools.css for CopyParty page styles
- add static/js/pages/tools.js with shared auth/layout bootstrap and 401 handling
- preserve CopyParty status/install/config flows and UI selectors used by tests
- update Docs/UI_MIGRATION_TRACKER.md to mark tools migrated

## Validation
- node --check static/js/pages/tools.js
- pytest -q tests/test_app.py::TestStaticPages::test_tools_page
- pytest -q tests/test_app.py::TestStaticPages
- tox -e all (via commit hook)
