### PR TITLE
Backfill migrated pages to shared state primitives

### DIFF
--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -61,6 +61,7 @@
 - [x] Migrate `tailscale`.
 - [x] Migrate `tools`.
 - [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
+  Pending backfill: `containers`, `system`.
 - [ ] Validate plugin-specific edge cases.
 
 ## Release readiness

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -60,8 +60,7 @@
 - [x] Migrate `network`.
 - [x] Migrate `tailscale`.
 - [x] Migrate `tools`.
-- [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
-  Pending backfill: `containers`, `system`.
+- [x] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
 - [ ] Validate plugin-specific edge cases.
 
 ## Release readiness

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -68,7 +68,7 @@
 
 - [x] All legacy pages replaced or intentionally kept.
   Intentionally kept: `static/storage.html` as redirect shim to `static/pools.html`.
-- [x] Theming parity validated.
-  Verified shared theme hooks on served pages (`/css/foundation.css`, `/js/theme.js`, `/theme-banner`, and nav shell wiring where applicable).
+- [ ] Theming parity validated.
+  Theme hooks are wired (`/css/foundation.css`, `/js/theme.js`, `/theme-banner`, nav shell), but page CSS still contains hardcoded colors that need token migration.
 - [ ] Mobile and desktop smoke checks completed.
 - [ ] Documentation updated.

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -66,7 +66,9 @@
 
 ## Release readiness
 
-- [ ] All legacy pages replaced or intentionally kept.
-- [ ] Theming parity validated.
+- [x] All legacy pages replaced or intentionally kept.
+  Intentionally kept: `static/storage.html` as redirect shim to `static/pools.html`.
+- [x] Theming parity validated.
+  Verified shared theme hooks on served pages (`/css/foundation.css`, `/js/theme.js`, `/theme-banner`, and nav shell wiring where applicable).
 - [ ] Mobile and desktop smoke checks completed.
 - [ ] Documentation updated.

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -60,7 +60,7 @@
 - [x] Migrate `network`.
 - [x] Migrate `tailscale`.
 - [x] Migrate `tools`.
-- [x] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
+- [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
 - [ ] Validate plugin-specific edge cases.
 
 ## Release readiness

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -61,7 +61,8 @@
 - [x] Migrate `tailscale`.
 - [x] Migrate `tools`.
 - [x] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
-- [ ] Validate plugin-specific edge cases.
+- [x] Validate plugin-specific edge cases.
+  Covered: unknown plugin categories, missing plugin IDs, non-OK plugin list/detail responses, and missing command streams.
 
 ## Release readiness
 

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -68,7 +68,7 @@
 
 - [x] All legacy pages replaced or intentionally kept.
   Intentionally kept: `static/storage.html` as redirect shim to `static/pools.html`.
-- [ ] Theming parity validated.
-  Theme hooks are wired (`/css/foundation.css`, `/js/theme.js`, `/theme-banner`, nav shell), but page CSS still contains hardcoded colors that need token migration.
+- [x] Theming parity validated.
+  Page CSS now uses shared token references from `static/css/foundation.css`; hardcoded hex values were removed from page-specific styles.
 - [ ] Mobile and desktop smoke checks completed.
-- [ ] Documentation updated.
+- [x] Documentation updated.

--- a/Docs/UI_MIGRATION_TRACKER.md
+++ b/Docs/UI_MIGRATION_TRACKER.md
@@ -60,7 +60,7 @@
 - [x] Migrate `network`.
 - [x] Migrate `tailscale`.
 - [x] Migrate `tools`.
-- [ ] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
+- [x] Backfill already-migrated pages that still use page-local shell/state markup instead of shared primitives.
 - [ ] Validate plugin-specific edge cases.
 
 ## Release readiness

--- a/Docs/UI_MODERNIZATION_PLAN.md
+++ b/Docs/UI_MODERNIZATION_PLAN.md
@@ -25,7 +25,8 @@ For this migration wave, the UI stack is:
 - Shared HTTP helper exists in `static/js/lib/http.js`.
 - Shared layout helper exists in `static/js/lib/layout.js`.
 - Shared state components exist in `static/js/lib/states.js`.
-- Legacy utility script `static/js/api.js` still exists for older pages and shared toast UI.
+- All migrated routes now rely on page modules and shared libs; legacy `static/js/api.js` is no longer loaded by page HTML.
+- Dashboard (`index.html`) keeps its custom hero markup but now initializes `ensureDashboardShell` for shared nav/notification primitives.
 
 ## Standards for migrated pages
 

--- a/static/apps.html
+++ b/static/apps.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/apps.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/containers.html
+++ b/static/containers.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/containers.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/css/apps.css
+++ b/static/css/apps.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }

--- a/static/css/containers.css
+++ b/static/css/containers.css
@@ -1,99 +1,98 @@
-        .status-running { background-color: #38a169; }
-        .status-stopped { background-color: #e53e3e; }
-        .status-other { background-color: #dd6b20; }
-        .button:active { transform: scale(0.95); } /* Add feedback on button click */
-        
-        /* Animation for container actions */
-        .animate-pulse {
-            animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-        }
-        
-        @keyframes pulse {
-            0%, 100% {
-                opacity: 1;
-            }
-            50% {
-                opacity: 0.5;
-            }
-        }
-        
-        /* Notification styles */
-        .notification {
-            transition: opacity 0.3s, height 0.3s, margin 0.3s, padding 0.3s;
-            overflow: hidden;
-        }
-        
-        /* Container row hover effect */
-        tr:hover:not(.loading-row) {
-            background-color: rgba(255, 255, 255, 0.05);
-        }
-        
-        /* Fade transition for container status changes */
-        .status-transition {
-            transition: background-color 0.5s ease;
-        }
-        
-        /* Disable text selection on buttons */
-        button {
-            user-select: none;
-        }
-        
-        /* Custom Coraline button */
-        .coraline-button {
-            background: linear-gradient(to bottom, #5f4b8b, #372b53);
-            border: 1px solid #8a6cbd;
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
-            transition: all 0.3s ease;
-        }
-        
-        .coraline-button:hover {
-            background: linear-gradient(to bottom, #6f58a3, #413162);
-            transform: translateY(-2px);
-            box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
-        }
-        
-        /* Loading spinner */
-        .loading-spinner {
-            display: inline-block;
-            width: 1rem;
-            height: 1rem;
-            border: 2px solid rgba(255, 255, 255, 0.3);
-            border-radius: 50%;
-            border-top-color: white;
-            animation: spin 1s ease-in-out infinite;
-        }
-        
-        @keyframes spin {
-            to { transform: rotate(360deg); }
-        }
+.status-running { background-color: var(--status-success-strong); }
+.status-stopped { background-color: var(--status-danger-strong); }
+.status-other { background-color: var(--status-warning-strong); }
+.button:active { transform: scale(0.95); } /* Add feedback on button click */
 
-        /* Action button styles */
-        .action-btn {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            min-width: 50px;
-            transition: all 0.2s;
-        }
+/* Animation for container actions */
+.animate-pulse {
+    animation: pulse 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
 
-        .action-btn:active:not(:disabled) {
-            transform: scale(0.95);
-        }
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
 
-        /* Dropdown menu - vertical list positioned to the left */
-        .dropdown-menu {
-            display: none;
-            flex-direction: column;
-            right: 0;
-        }
+/* Notification styles */
+.notification {
+    transition: opacity 0.3s, height 0.3s, margin 0.3s, padding 0.3s;
+    overflow: hidden;
+}
 
-        .dropdown-menu:not(.hidden) {
-            display: flex;
-        }
+/* Container row hover effect */
+tr:hover:not(.loading-row) {
+    background-color: rgba(255, 255, 255, 0.05);
+}
 
-        .dropdown-menu button {
-            display: block;
-            width: 100%;
-            white-space: nowrap;
-        }
-    </style>
+/* Fade transition for container status changes */
+.status-transition {
+    transition: background-color 0.5s ease;
+}
+
+/* Disable text selection on buttons */
+button {
+    user-select: none;
+}
+
+/* Custom Coraline button */
+.coraline-button {
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
+    transition: all 0.3s ease;
+}
+
+.coraline-button:hover {
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
+    transform: translateY(-2px);
+    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
+}
+
+/* Loading spinner */
+.loading-spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50%;
+    border-top-color: white;
+    animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Action button styles */
+.action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 50px;
+    transition: all 0.2s;
+}
+
+.action-btn:active:not(:disabled) {
+    transform: scale(0.95);
+}
+
+/* Dropdown menu - vertical list positioned to the left */
+.dropdown-menu {
+    display: none;
+    flex-direction: column;
+    right: 0;
+}
+
+.dropdown-menu:not(.hidden) {
+    display: flex;
+}
+
+.dropdown-menu button {
+    display: block;
+    width: 100%;
+    white-space: nowrap;
+}

--- a/static/css/disks.css
+++ b/static/css/disks.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -23,7 +23,7 @@
 .progress-bar {
     height: 8px;
     border-radius: 4px;
-    background: #374151;
+    background: var(--surface-gray-700);
     overflow: hidden;
 }
 
@@ -33,31 +33,31 @@
 }
 
 .mounted {
-    color: #34d399;
+    color: var(--status-success);
 }
 
 .unmounted {
-    color: #fbbf24;
+    color: var(--status-warning);
 }
 
 .missing {
-    color: #f87171;
+    color: var(--status-danger);
 }
 
 .smart-healthy {
-    color: #34d399;
+    color: var(--status-success);
 }
 
 .smart-warning {
-    color: #fbbf24;
+    color: var(--status-warning);
 }
 
 .smart-failing {
-    color: #f87171;
+    color: var(--status-danger);
 }
 
 .smart-unknown {
-    color: #9ca3af;
+    color: var(--status-neutral);
 }
 
 .smart-badge {
@@ -71,26 +71,26 @@
 
 .smart-badge.healthy {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .smart-badge.warning {
     background-color: rgba(251, 191, 36, 0.2);
-    color: #fbbf24;
-    border: 1px solid #fbbf24;
+    color: var(--status-warning);
+    border: 1px solid var(--status-warning);
 }
 
 .smart-badge.failing {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }
 
 .smart-badge.unknown {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }
 
 .smart-attr-row:hover {

--- a/static/css/foundation.css
+++ b/static/css/foundation.css
@@ -16,8 +16,63 @@
 
     --accent: #0f766e;
     --accent-strong: #115e59;
+    --accent-alt: #0b8a80;
     --accent-contrast: #f0fdfa;
     --danger: #b91c1c;
+    --danger-700: #991b1b;
+    --warning-700: #b45309;
+    --warning-800: #92400e;
+    --success-700: #15803d;
+
+    --coraline-600: #6f58a3;
+    --coraline-700: #5f4b8b;
+    --coraline-800: #372b53;
+    --coraline-900: #413162;
+    --coraline-border: #8a6cbd;
+    --coraline-accent: #7c3aed;
+    --coraline-accent-2: #8b5cf6;
+    --coraline-accent-dark: #553c9a;
+
+    --status-success: #34d399;
+    --status-success-strong: #38a169;
+    --status-warning: #fbbf24;
+    --status-warning-strong: #dd6b20;
+    --status-danger: #f87171;
+    --status-danger-strong: #e53e3e;
+    --status-neutral: #9ca3af;
+    --status-neutral-strong: #718096;
+
+    --surface-white: #ffffff;
+    --surface-gray-900: #1a1a2e;
+    --surface-gray-850: #1a202c;
+    --surface-gray-800: #2d3748;
+    --surface-gray-700: #374151;
+    --surface-gray-600: #4b5563;
+    --surface-gray-550: #4a5568;
+    --surface-gray-500: #5a6578;
+    --surface-gray-200: #e5e7eb;
+    --surface-gray-100: #e2e8f0;
+
+    --text-slate-800: #1e293b;
+    --text-slate-700: #334155;
+    --text-slate-600: #475569;
+    --text-slate-500: #64748b;
+    --text-gray-500: #6b7280;
+    --text-placeholder: #8b96ab;
+
+    --border-gray-400: #a0aec0;
+
+    --gradient-page-top: #f6fbff;
+    --gradient-page-bottom: #ebf4fb;
+    --gradient-page-bottom-alt: #e9f3fb;
+
+    --syntax-danger-soft: #f56565;
+    --syntax-danger-light: #feb2b2;
+    --syntax-orange: #f6ad55;
+    --syntax-red: #fc8181;
+    --syntax-green: #68d391;
+    --syntax-blue: #90cdf4;
+    --syntax-purple: #b794f4;
 
     --radius-sm: 12px;
     --radius-md: 18px;
@@ -124,7 +179,7 @@ body {
 }
 
 .ph-input::placeholder {
-    color: #8b96ab;
+    color: var(--text-placeholder);
 }
 
 .ph-button {
@@ -136,7 +191,7 @@ body {
     letter-spacing: 0.01em;
     padding: 14px 16px;
     cursor: pointer;
-    background: linear-gradient(135deg, var(--accent), #0b8a80);
+    background: linear-gradient(135deg, var(--accent), var(--accent-alt));
     transition: transform 150ms ease, box-shadow 150ms ease, filter 150ms ease;
     box-shadow: 0 12px 24px rgba(15, 118, 110, 0.28);
     display: inline-flex;
@@ -187,7 +242,7 @@ body {
     width: 1rem;
     height: 1rem;
     border: 2px solid rgba(240, 253, 250, 0.35);
-    border-top-color: #f0fdfa;
+    border-top-color: var(--accent-contrast);
     border-radius: 999px;
     animation: ph-spin 700ms linear infinite;
 }

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -3,7 +3,7 @@
     background:
         radial-gradient(1200px 680px at -8% -18%, rgba(14, 165, 233, 0.18), transparent 62%),
         radial-gradient(900px 580px at 108% -24%, rgba(251, 146, 60, 0.18), transparent 62%),
-        linear-gradient(180deg, #f6fbff 0%, #ebf4fb 100%);
+        linear-gradient(180deg, var(--gradient-page-top) 0%, var(--gradient-page-bottom) 100%);
 }
 
 .ph-home-hero {
@@ -26,7 +26,7 @@
     font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #6b7280;
+    color: var(--text-gray-500);
 }
 
 .ph-home-title {
@@ -37,12 +37,12 @@
 
 .ph-home-subtitle {
     margin: 6px 0 0;
-    color: #64748b;
+    color: var(--text-slate-500);
     font-size: 0.92rem;
 }
 
 .ph-home-meta {
-    color: #475569;
+    color: var(--text-slate-600);
     font-size: 0.86rem;
     font-family: var(--font-mono);
 }
@@ -67,13 +67,13 @@
     display: grid;
     place-items: center;
     text-align: center;
-    color: #475569;
+    color: var(--text-slate-600);
     padding: 16px;
 }
 
 .ph-state[data-tone='error'] {
     border-color: rgba(185, 28, 28, 0.32);
-    color: #991b1b;
+    color: var(--danger-700);
 }
 
 .ph-service-card {
@@ -96,7 +96,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #f8fafc;
+    color: var(--text-inverse);
 }
 
 .ph-service-banner svg {
@@ -118,7 +118,7 @@
 .ph-service-port {
     margin: 8px 0 14px;
     font-size: 0.84rem;
-    color: #64748b;
+    color: var(--text-slate-500);
     font-family: var(--font-mono);
 }
 
@@ -129,8 +129,8 @@
     justify-content: center;
     border-radius: 13px;
     padding: 10px 14px;
-    background: linear-gradient(135deg, #0f766e, #0b8a80);
-    color: #f0fdfa;
+    background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+    color: var(--accent-contrast);
     font-weight: 600;
     letter-spacing: 0.01em;
     box-shadow: 0 12px 24px rgba(15, 118, 110, 0.24);
@@ -146,7 +146,7 @@
     border-radius: 12px;
     padding: 9px 14px;
     border: 1px solid rgba(15, 23, 42, 0.18);
-    color: #0f172a;
+    color: var(--text-primary);
     text-decoration: none;
     font-weight: 600;
     background: rgba(255, 255, 255, 0.92);

--- a/static/css/mounts.css
+++ b/static/css/mounts.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,18 +26,18 @@
 
 .status-connected {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-disconnected {
     background-color: rgba(251, 191, 36, 0.2);
-    color: #fbbf24;
-    border: 1px solid #fbbf24;
+    color: var(--status-warning);
+    border: 1px solid var(--status-warning);
 }
 
 .status-error {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }

--- a/static/css/network.css
+++ b/static/css/network.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,20 +26,20 @@
 
 .status-up {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-down {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }
 
 .status-unknown {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }
 
 .info-card {
@@ -50,14 +50,14 @@
 }
 
 .info-label {
-    color: #9ca3af;
+    color: var(--status-neutral);
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
 
 .info-value {
-    color: #e5e7eb;
+    color: var(--surface-gray-200);
     font-size: 1rem;
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
 }

--- a/static/css/plugins.css
+++ b/static/css/plugins.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,20 +26,20 @@
 
 .status-healthy {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-error {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }
 
 .status-unconfigured {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }
 
 .toggle-switch {
@@ -62,7 +62,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #4a5568;
+    background-color: var(--surface-gray-550);
     transition: 0.3s;
     border-radius: 24px;
 }
@@ -74,13 +74,13 @@
     width: 18px;
     left: 3px;
     bottom: 3px;
-    background-color: #fff;
+    background-color: var(--surface-white);
     transition: 0.3s;
     border-radius: 50%;
 }
 
 input:checked + .toggle-slider {
-    background-color: #7c3aed;
+    background-color: var(--coraline-accent);
 }
 
 input:checked + .toggle-slider:before {

--- a/static/css/pools.css
+++ b/static/css/pools.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,26 +26,26 @@
 
 .status-healthy {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-degraded {
     background-color: rgba(251, 191, 36, 0.2);
-    color: #fbbf24;
-    border: 1px solid #fbbf24;
+    color: var(--status-warning);
+    border: 1px solid var(--status-warning);
 }
 
 .status-error {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }
 
 .status-unconfigured {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }
 
 .output-panel {

--- a/static/css/settings.css
+++ b/static/css/settings.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -36,7 +36,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #4a5568;
+    background-color: var(--surface-gray-550);
     transition: 0.3s;
     border-radius: 26px;
 }
@@ -48,13 +48,13 @@
     width: 20px;
     left: 3px;
     bottom: 3px;
-    background-color: #ffffff;
+    background-color: var(--surface-white);
     transition: 0.3s;
     border-radius: 50%;
 }
 
 input:checked + .toggle-slider {
-    background-color: #38a169;
+    background-color: var(--status-success-strong);
 }
 
 input:checked + .toggle-slider::before {
@@ -63,25 +63,25 @@ input:checked + .toggle-slider::before {
 
 .schedule-btn {
     padding: 0.75rem 1.5rem;
-    background-color: #4a5568;
+    background-color: var(--surface-gray-550);
     border: 2px solid transparent;
     border-radius: 0.5rem;
     transition: all 0.2s ease;
 }
 
 .schedule-btn:hover {
-    background-color: #5a6578;
+    background-color: var(--surface-gray-500);
 }
 
 .schedule-btn.selected {
-    background-color: #5f4b8b;
-    border-color: #8a6cbd;
+    background-color: var(--coraline-700);
+    border-color: var(--coraline-border);
 }
 
 .notification {
     padding: 1rem;
     border-radius: 0.5rem;
-    color: #ffffff;
+    color: var(--surface-white);
     max-width: 400px;
 }
 
@@ -91,7 +91,7 @@ input:checked + .toggle-slider::before {
     height: 1rem;
     border: 2px solid rgba(255, 255, 255, 0.3);
     border-radius: 50%;
-    border-top-color: #ffffff;
+    border-top-color: var(--surface-white);
     animation: spin 1s ease-in-out infinite;
 }
 

--- a/static/css/shares.css
+++ b/static/css/shares.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,26 +26,26 @@
 
 .status-healthy {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-degraded {
     background-color: rgba(251, 191, 36, 0.2);
-    color: #fbbf24;
-    border: 1px solid #fbbf24;
+    color: var(--status-warning);
+    border: 1px solid var(--status-warning);
 }
 
 .status-error {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }
 
 .status-unconfigured {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }
 
 .toggle-switch {
@@ -68,7 +68,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #4b5563;
+    background-color: var(--surface-gray-600);
     transition: 0.3s;
     border-radius: 24px;
 }
@@ -80,13 +80,13 @@
     width: 18px;
     left: 3px;
     bottom: 3px;
-    background-color: #fff;
+    background-color: var(--surface-white);
     transition: 0.3s;
     border-radius: 50%;
 }
 
 input:checked + .toggle-slider {
-    background-color: #8b5cf6;
+    background-color: var(--coraline-accent-2);
 }
 
 input:checked + .toggle-slider:before {

--- a/static/css/stacks.css
+++ b/static/css/stacks.css
@@ -1,17 +1,17 @@
-.status-running { background-color: #38a169; }
-.status-stopped { background-color: #e53e3e; }
-.status-partial { background-color: #dd6b20; }
-.status-unknown { background-color: #718096; }
+.status-running { background-color: var(--status-success-strong); }
+.status-stopped { background-color: var(--status-danger-strong); }
+.status-partial { background-color: var(--status-warning-strong); }
+.status-unknown { background-color: var(--status-neutral-strong); }
 
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -22,7 +22,7 @@
 }
 
 .terminal-output {
-    background-color: #1a1a2e;
+    background-color: var(--surface-gray-900);
     font-family: 'Courier New', monospace;
     font-size: 12px;
     line-height: 1.4;
@@ -43,14 +43,14 @@
 }
 
 .editor-error {
-    border-color: #f56565;
+    border-color: var(--syntax-danger-soft);
     box-shadow: 0 0 0 1px rgba(245, 101, 101, 0.6);
 }
 
 .error-banner {
     background-color: rgba(245, 101, 101, 0.15);
     border: 1px solid rgba(245, 101, 101, 0.6);
-    color: #feb2b2;
+    color: var(--syntax-danger-light);
 }
 
 .stack-card {
@@ -66,46 +66,46 @@
 
 .CodeMirror {
     height: 360px;
-    background-color: #1a202c;
-    color: #e2e8f0;
+    background-color: var(--surface-gray-850);
+    color: var(--surface-gray-100);
     border-radius: 0.375rem;
-    border: 1px solid #4a5568;
+    border: 1px solid var(--surface-gray-550);
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
     font-size: 14px;
 }
 
 .CodeMirror-gutters {
-    background-color: #2d3748;
-    border-right: 1px solid #4a5568;
+    background-color: var(--surface-gray-800);
+    border-right: 1px solid var(--surface-gray-550);
 }
 
 .CodeMirror-linenumber {
-    color: #718096;
+    color: var(--status-neutral-strong);
 }
 
 .CodeMirror-cursor {
-    border-left: 2px solid #a0aec0;
+    border-left: 2px solid var(--border-gray-400);
 }
 
 .CodeMirror-selected {
-    background: #4a5568 !important;
+    background: var(--surface-gray-550) !important;
 }
 
 .CodeMirror-focused .CodeMirror-selected {
-    background: #553c9a !important;
+    background: var(--coraline-accent-dark) !important;
 }
 
 /* YAML syntax highlighting for dark theme */
-.cm-s-default .cm-atom { color: #f6ad55; }
-.cm-s-default .cm-number { color: #f6ad55; }
-.cm-s-default .cm-keyword { color: #fc8181; }
-.cm-s-default .cm-def { color: #68d391; }
-.cm-s-default .cm-variable { color: #e2e8f0; }
-.cm-s-default .cm-variable-2 { color: #90cdf4; }
-.cm-s-default .cm-string { color: #68d391; }
-.cm-s-default .cm-string-2 { color: #68d391; }
-.cm-s-default .cm-comment { color: #718096; }
-.cm-s-default .cm-meta { color: #b794f4; }
+.cm-s-default .cm-atom { color: var(--syntax-orange); }
+.cm-s-default .cm-number { color: var(--syntax-orange); }
+.cm-s-default .cm-keyword { color: var(--syntax-red); }
+.cm-s-default .cm-def { color: var(--syntax-green); }
+.cm-s-default .cm-variable { color: var(--surface-gray-100); }
+.cm-s-default .cm-variable-2 { color: var(--syntax-blue); }
+.cm-s-default .cm-string { color: var(--syntax-green); }
+.cm-s-default .cm-string-2 { color: var(--syntax-green); }
+.cm-s-default .cm-comment { color: var(--status-neutral-strong); }
+.cm-s-default .cm-meta { color: var(--syntax-purple); }
 
 @keyframes pulse {
     0%, 100% { opacity: 1; }

--- a/static/css/system.css
+++ b/static/css/system.css
@@ -3,7 +3,7 @@
     background:
         radial-gradient(1000px 560px at -8% -20%, rgba(14, 165, 233, 0.2), transparent 62%),
         radial-gradient(920px 540px at 108% -24%, rgba(20, 184, 166, 0.2), transparent 62%),
-        linear-gradient(180deg, #f6fbff 0%, #e9f3fb 100%);
+        linear-gradient(180deg, var(--gradient-page-top) 0%, var(--gradient-page-bottom-alt) 100%);
 }
 
 .ph-system-shell {
@@ -31,7 +31,7 @@
     font-size: 0.78rem;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #64748b;
+    color: var(--text-slate-500);
 }
 
 .ph-system-title {
@@ -42,7 +42,7 @@
 
 .ph-system-updated {
     font-size: 0.88rem;
-    color: #475569;
+    color: var(--text-slate-600);
     font-family: var(--font-mono);
 }
 
@@ -63,19 +63,19 @@
 .ph-card-title {
     margin: 0;
     font-size: 1rem;
-    color: #1e293b;
+    color: var(--text-slate-800);
 }
 
 .ph-value {
     margin-top: 8px;
     font-size: 1.3rem;
     font-weight: 700;
-    color: #0f172a;
+    color: var(--text-primary);
 }
 
 .ph-metric-row {
     margin-top: 8px;
-    color: #334155;
+    color: var(--text-slate-700);
 }
 
 .ph-progress {
@@ -112,8 +112,8 @@
 .ph-btn {
     border: 1px solid rgba(15, 23, 42, 0.2);
     border-radius: 13px;
-    background: linear-gradient(135deg, #0f766e, #0b8a80);
-    color: #f0fdfa;
+    background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+    color: var(--accent-contrast);
     font: inherit;
     font-weight: 600;
     padding: 10px 14px;
@@ -121,27 +121,27 @@
 }
 
 .ph-btn[data-action='shutdown'] {
-    background: linear-gradient(135deg, #b91c1c, #991b1b);
+    background: linear-gradient(135deg, var(--danger), var(--danger-700));
 }
 
 .ph-btn[data-action='reboot'] {
-    background: linear-gradient(135deg, #b45309, #92400e);
+    background: linear-gradient(135deg, var(--warning-700), var(--warning-800));
 }
 
 .ph-muted {
-    color: #64748b;
+    color: var(--text-slate-500);
 }
 
 .ph-positive {
-    color: #15803d;
+    color: var(--success-700);
 }
 
 .ph-warn {
-    color: #b45309;
+    color: var(--warning-700);
 }
 
 .ph-danger {
-    color: #b91c1c;
+    color: var(--danger);
 }
 
 .fade-in {

--- a/static/css/tailscale.css
+++ b/static/css/tailscale.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,20 +26,20 @@
 
 .status-connected {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-disconnected {
     background-color: rgba(248, 113, 113, 0.2);
-    color: #f87171;
-    border: 1px solid #f87171;
+    color: var(--status-danger);
+    border: 1px solid var(--status-danger);
 }
 
 .status-not-installed {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }
 
 .info-card {
@@ -50,14 +50,14 @@
 }
 
 .info-label {
-    color: #9ca3af;
+    color: var(--status-neutral);
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
 
 .info-value {
-    color: #e5e7eb;
+    color: var(--surface-gray-200);
     font-size: 1rem;
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
 }

--- a/static/css/tools.css
+++ b/static/css/tools.css
@@ -1,12 +1,12 @@
 .coraline-button {
-    background: linear-gradient(to bottom, #5f4b8b, #372b53);
-    border: 1px solid #8a6cbd;
+    background: linear-gradient(to bottom, var(--coraline-700), var(--coraline-800));
+    border: 1px solid var(--coraline-border);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.25);
     transition: all 0.3s ease;
 }
 
 .coraline-button:hover:not(:disabled) {
-    background: linear-gradient(to bottom, #6f58a3, #413162);
+    background: linear-gradient(to bottom, var(--coraline-600), var(--coraline-900));
     transform: translateY(-2px);
     box-shadow: 0 6px 10px rgba(0, 0, 0, 0.3);
 }
@@ -26,18 +26,18 @@
 
 .status-healthy {
     background-color: rgba(52, 211, 153, 0.2);
-    color: #34d399;
-    border: 1px solid #34d399;
+    color: var(--status-success);
+    border: 1px solid var(--status-success);
 }
 
 .status-degraded {
     background-color: rgba(251, 191, 36, 0.2);
-    color: #fbbf24;
-    border: 1px solid #fbbf24;
+    color: var(--status-warning);
+    border: 1px solid var(--status-warning);
 }
 
 .status-unconfigured {
     background-color: rgba(156, 163, 175, 0.2);
-    color: #9ca3af;
-    border: 1px solid #9ca3af;
+    color: var(--status-neutral);
+    border: 1px solid var(--status-neutral);
 }

--- a/static/disks.html
+++ b/static/disks.html
@@ -35,7 +35,7 @@
                 <p class="text-gray-400 text-sm mt-1">View and manage storage devices</p>
             </div>
             <div class="flex space-x-2">
-                <button onclick="loadDisks()" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded flex items-center">
+                <button id="disks-refresh-btn" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded flex items-center">
                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                     </svg>
@@ -57,7 +57,7 @@
                     <h3 class="text-lg font-semibold">SMART Health</h3>
                     <p class="text-gray-400 text-sm">Disk health monitoring via S.M.A.R.T.</p>
                 </div>
-                <button onclick="loadSmartData()" class="coraline-button text-blue-100 py-2 px-4 rounded text-sm flex items-center">
+                <button id="disks-smart-refresh-btn" class="coraline-button text-blue-100 py-2 px-4 rounded text-sm flex items-center">
                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                     </svg>
@@ -79,7 +79,7 @@
         <div class="bg-gray-900 w-full max-w-lg rounded-lg shadow-xl border border-purple-900 flex flex-col">
             <div class="flex justify-between items-center p-4 border-b border-purple-800">
                 <h3 id="mount-title" class="text-xl font-semibold">Mount Partition</h3>
-                <button onclick="closeMountModal()" class="text-gray-400 hover:text-gray-200">Close</button>
+                <button id="disks-close-mount-top" class="text-gray-400 hover:text-gray-200">Close</button>
             </div>
             <div class="p-4 space-y-4">
                 <div>
@@ -104,17 +104,17 @@
                 </div>
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-end space-x-2">
-                <button onclick="closeMountModal()" class="px-4 py-2 bg-gray-700 text-white rounded">Cancel</button>
-                <button onclick="submitMount()" class="coraline-button px-4 py-2 text-white rounded">Mount</button>
+                <button id="disks-close-mount-bottom" class="px-4 py-2 bg-gray-700 text-white rounded">Cancel</button>
+                <button id="disks-submit-mount" class="coraline-button px-4 py-2 text-white rounded">Mount</button>
             </div>
         </div>
     </div>
 
-    <div id="smart-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 items-center justify-center p-4 overflow-hidden" onclick="if(event.target === this) closeSmartModal()">
-        <div class="bg-gray-900 w-full max-w-2xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh]" onclick="event.stopPropagation()">
+    <div id="smart-modal" data-overlay-close class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 items-center justify-center p-4 overflow-hidden">
+        <div data-modal-panel class="bg-gray-900 w-full max-w-2xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh]">
             <div class="flex justify-between items-center p-4 border-b border-purple-800 flex-shrink-0">
                 <h3 id="smart-modal-title" class="text-xl font-semibold">SMART Details</h3>
-                <button onclick="closeSmartModal()" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
+                <button id="disks-close-smart-top" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
             </div>
             <div class="p-4 overflow-y-auto flex-1 min-h-0">
                 <div id="smart-modal-content">
@@ -122,10 +122,10 @@
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-between items-center flex-shrink-0">
                 <div class="flex gap-2">
-                    <button onclick="runSmartTest('short')" class="coraline-button px-3 py-2 text-sm rounded text-white">Short Test</button>
-                    <button onclick="runSmartTest('long')" class="coraline-button px-3 py-2 text-sm rounded text-white">Long Test</button>
+                    <button data-smart-test="short" class="coraline-button px-3 py-2 text-sm rounded text-white">Short Test</button>
+                    <button data-smart-test="long" class="coraline-button px-3 py-2 text-sm rounded text-white">Long Test</button>
                 </div>
-                <button onclick="closeSmartModal()" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Close</button>
+                <button id="disks-close-smart-bottom" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Close</button>
             </div>
         </div>
     </div>

--- a/static/disks.html
+++ b/static/disks.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/disks.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/index.html
+++ b/static/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/index.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/js/lib/dom.js
+++ b/static/js/lib/dom.js
@@ -1,0 +1,14 @@
+import { clearElement } from '/js/lib/states.js';
+
+export function setNodeContent(containerOrId, node) {
+    const container = typeof containerOrId === 'string'
+        ? document.getElementById(containerOrId)
+        : containerOrId;
+
+    if (!container) {
+        return;
+    }
+
+    clearElement(container);
+    container.appendChild(node);
+}

--- a/static/js/lib/format.js
+++ b/static/js/lib/format.js
@@ -1,0 +1,29 @@
+export function escapeHtml(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+export function encodeDataAttr(value) {
+    return escapeHtml(String(value ?? ''));
+}
+
+export function formatBytes(bytes, decimals = 2) {
+    const value = Number(bytes);
+    if (!Number.isFinite(value) || value <= 0) {
+        return '0 B';
+    }
+
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.min(Math.floor(Math.log(value) / Math.log(k)), sizes.length - 1);
+
+    return `${parseFloat((value / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
+}

--- a/static/js/lib/http.js
+++ b/static/js/lib/http.js
@@ -1,3 +1,5 @@
+import { clearClientSession } from '/js/lib/session.js';
+
 export async function requestJson(url, options = {}) {
     const response = await fetch(url, options);
     let payload = null;
@@ -9,4 +11,36 @@ export async function requestJson(url, options = {}) {
     }
 
     return { response, payload };
+}
+
+export async function requestApiResponse(url, options = {}) {
+    const response = await fetch(url, options);
+
+    if (response.status === 401) {
+        clearClientSession();
+        window.location.href = '/login.html';
+        throw new Error('Authentication required');
+    }
+
+    return response;
+}
+
+export async function requestApiJson(url, options = {}) {
+    const response = await requestApiResponse(url, options);
+    let payload = null;
+
+    try {
+        payload = await response.json();
+    } catch (_err) {
+        payload = null;
+    }
+
+    if (!response.ok) {
+        const error = new Error(payload?.error || payload?.stderr || `Request failed (${response.status})`);
+        error.status = response.status;
+        error.payload = payload;
+        throw error;
+    }
+
+    return payload || {};
 }

--- a/static/js/lib/notify.js
+++ b/static/js/lib/notify.js
@@ -1,0 +1,38 @@
+const DEFAULT_COLORS = {
+    success: 'bg-green-600',
+    error: 'bg-red-600',
+    warning: 'bg-yellow-700',
+    info: 'bg-blue-600',
+};
+
+export function showNotification(message, type = 'info', options = {}) {
+    const {
+        areaId = 'notification-area',
+        duration = 3000,
+        baseClass = 'p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0 text-white',
+        animate = true,
+        colorMap = DEFAULT_COLORS,
+    } = options;
+
+    const area = document.getElementById(areaId);
+    if (!area) {
+        return;
+    }
+
+    const notification = document.createElement('div');
+    notification.className = baseClass;
+    notification.classList.add(colorMap[type] || colorMap.info || DEFAULT_COLORS.info);
+    notification.textContent = message;
+    area.appendChild(notification);
+
+    if (!animate) {
+        window.setTimeout(() => notification.remove(), duration);
+        return;
+    }
+
+    window.setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
+    window.setTimeout(() => {
+        notification.classList.replace('opacity-100', 'opacity-0');
+        window.setTimeout(() => notification.remove(), 300);
+    }, duration);
+}

--- a/static/js/pages/apps.js
+++ b/static/js/pages/apps.js
@@ -1,7 +1,8 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
-import { requestJson } from '/js/lib/http.js';
+import { requestApiJson, requestApiResponse } from '/js/lib/http.js';
+import { showNotification } from '/js/lib/notify.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-72 flex flex-col items-end',
@@ -15,51 +16,17 @@ let availableStacks = [];
 let activeInstall = null;
 let activeRemove = null;
 
-function showNotification(message, type = 'info') {
-    if (typeof window.showToast === 'function') {
-        window.showToast(message, type);
-        return;
-    }
-
-    const notificationArea = document.getElementById('notification-area');
-    const notification = document.createElement('div');
-    notification.className = 'bg-opacity-90 p-3 mb-2 rounded shadow-lg transform transition-all duration-500 opacity-0';
-
-    if (type === 'success') notification.classList.add('bg-green-600');
-    else if (type === 'error') notification.classList.add('bg-red-600');
-    else notification.classList.add('bg-blue-600');
-
-    notification.textContent = message;
-    notificationArea.appendChild(notification);
-    window.setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    window.setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        window.setTimeout(() => notification.remove(), 300);
-    }, 3000);
-}
-
 async function requestApi(url, options = {}) {
-    const { response, payload } = await requestJson(url, options);
+    const response = await requestApiResponse(url, options);
+    let payload = {};
 
-    if (response.status === 401) {
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
+    try {
+        payload = await response.json();
+    } catch (_err) {
+        payload = {};
     }
 
-    return { response, payload: payload || {} };
-}
-
-async function requestApiJson(url, options = {}) {
-    const { response, payload } = await requestApi(url, options);
-
-    if (!response.ok) {
-        const err = new Error(payload.error || payload.stderr || `Request failed (${response.status})`);
-        err.status = response.status;
-        err.data = payload;
-        throw err;
-    }
-
-    return payload;
+    return { response, payload };
 }
 
 function showLoadingState(message = 'Loading catalog...') {

--- a/static/js/pages/containers.js
+++ b/static/js/pages/containers.js
@@ -1,9 +1,14 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 import { requestApiJson } from '/js/lib/http.js';
 import { formatBytes as formatBaseBytes } from '/js/lib/format.js';
 import { showNotification as showBaseNotification } from '/js/lib/notify.js';
 
-window.logout = logoutToLogin;
+ensureDashboardShell({
+    notificationClass: 'fixed top-4 right-4 z-50 w-72 flex flex-col items-end',
+    includeFooter: true,
+});
 
 function showNotification(message, type = 'info') {
     showBaseNotification(message, type, {
@@ -162,7 +167,7 @@ function clearContainerList() {
     list.textContent = '';
 }
 
-function appendTableMessage(message, className = '') {
+function appendTableState(stateNode) {
     const list = getContainerListEl();
     if (!list) return;
 
@@ -171,10 +176,34 @@ function appendTableMessage(message, className = '') {
     const row = document.createElement('tr');
     const cell = document.createElement('td');
     cell.colSpan = 8;
-    cell.className = `text-center py-4 ${className}`.trim();
-    cell.textContent = message;
+    cell.className = 'px-4 py-4';
+    cell.appendChild(stateNode);
     row.appendChild(cell);
     list.appendChild(row);
+}
+
+function showContainersLoadingState(message = 'Loading containers...') {
+    appendTableState(createLoadingState({
+        message,
+        containerClass: 'text-center py-2',
+        messageClass: 'text-gray-400',
+    }));
+}
+
+function showContainersEmptyState(title) {
+    appendTableState(createEmptyState({
+        title,
+        containerClass: 'text-center py-2',
+        titleClass: 'text-gray-400',
+    }));
+}
+
+function showContainersErrorState(title) {
+    appendTableState(createErrorState({
+        title,
+        containerClass: 'text-center py-2',
+        titleClass: 'text-red-500',
+    }));
 }
 
 function renderContainerNameCell(cell, container) {
@@ -496,7 +525,7 @@ function renderContainers(showStatsLoading = false) {
     });
 
     if (filteredContainers.length === 0) {
-        appendTableMessage(`No ${currentFilter} containers found`);
+        showContainersEmptyState(`No ${currentFilter} containers found`);
         return;
     }
 
@@ -517,7 +546,7 @@ async function fetchDockerContainers(forceFullRender = false, includeStats = fal
     const lastUpdatedEl = document.getElementById('last-updated');
 
     if (!initialLoadComplete) {
-        appendTableMessage('Loading...');
+        showContainersLoadingState('Loading containers...');
     }
 
     try {
@@ -550,7 +579,7 @@ async function fetchDockerContainers(forceFullRender = false, includeStats = fal
     } catch (error) {
         console.error('Error fetching Docker containers:', error);
         if (!initialLoadComplete) {
-            appendTableMessage('Error loading containers', 'text-red-500');
+            showContainersErrorState('Error loading containers');
         }
         showNotification('Error fetching containers', 'error');
     }
@@ -953,6 +982,7 @@ async function initContainersPage() {
     const authenticated = await ensureAuthenticated();
     if (!authenticated) return;
 
+    window.logout = logoutToLogin;
     bindModalHandlers();
     bindStaticControls();
     bindContainerTableActions();

--- a/static/js/pages/containers.js
+++ b/static/js/pages/containers.js
@@ -5,785 +5,995 @@ window.logout = logoutToLogin;
 
 async function requestApiJson(url, options = {}) {
     const { response, payload } = await requestJson(url, options);
+
     if (!response.ok) {
         throw new Error(payload?.error || `Request failed (${response.status})`);
     }
-    return payload;
+
+    return payload || {};
 }
 
-        // Format timestamp
-        function formatDateTime(date) {
-            const hours = String(date.getHours()).padStart(2, '0');
-            const minutes = String(date.getMinutes()).padStart(2, '0');
-            const seconds = String(date.getSeconds()).padStart(2, '0');
-            return `${hours}:${minutes}:${seconds}`;
+function showNotification(message, type = 'info') {
+    const area = document.getElementById('notification-area');
+    if (!area) {
+        return;
+    }
+
+    const notification = document.createElement('div');
+    notification.className = 'bg-opacity-90 p-3 mb-2 rounded shadow-lg transform transition-all duration-500 opacity-0 text-white';
+
+    if (type === 'success') {
+        notification.classList.add('bg-green-600');
+    } else if (type === 'error') {
+        notification.classList.add('bg-red-600');
+    } else {
+        notification.classList.add('bg-blue-600');
+    }
+
+    notification.textContent = message;
+    area.appendChild(notification);
+
+    window.setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
+    window.setTimeout(() => {
+        notification.classList.replace('opacity-100', 'opacity-0');
+        window.setTimeout(() => notification.remove(), 300);
+    }, 3000);
+}
+
+function formatDateTime(date) {
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+    return `${hours}:${minutes}:${seconds}`;
+}
+
+function formatBytes(bytes) {
+    const value = Number(bytes);
+    if (!Number.isFinite(value) || value < 0) return '—';
+    if (value === 0) return '0 B';
+
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(Math.floor(Math.log(value) / Math.log(k)), sizes.length - 1);
+    return `${parseFloat((value / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+}
+
+function getStatColorClass(percent) {
+    if (!Number.isFinite(percent)) return 'text-gray-500';
+    if (percent < 50) return 'text-green-400';
+    if (percent < 80) return 'text-yellow-400';
+    return 'text-red-400';
+}
+
+function loadingSpinner() {
+    return '<div class="loading-spinner"></div>';
+}
+
+function normalizePercent(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+}
+
+function formatCpuCell(cpuPercent, loading = false) {
+    if (loading) return loadingSpinner();
+    const pct = normalizePercent(cpuPercent);
+    if (pct === null) return '<span class="text-gray-500">—</span>';
+
+    const colorClass = getStatColorClass(pct);
+    const barColor = pct < 50 ? 'bg-green-500' : pct < 80 ? 'bg-yellow-500' : 'bg-red-500';
+    return `
+        <span class="${colorClass} text-sm">${pct.toFixed(1)}%</span>
+        <div class="w-full bg-gray-700 rounded-full h-1.5 mt-1">
+            <div class="${barColor} h-1.5 rounded-full" style="width: ${Math.min(pct, 100)}%"></div>
+        </div>
+    `;
+}
+
+function formatMemoryCell(memPercent, memUsed, memLimit, loading = false) {
+    if (loading) return loadingSpinner();
+    const pct = normalizePercent(memPercent);
+    if (pct === null) return '<span class="text-gray-500">—</span>';
+
+    const colorClass = getStatColorClass(pct);
+    const barColor = pct < 50 ? 'bg-green-500' : pct < 80 ? 'bg-yellow-500' : 'bg-red-500';
+    return `
+        <span class="${colorClass} text-sm">${pct.toFixed(1)}%</span>
+        <div class="text-xs text-gray-400">${formatBytes(memUsed)} / ${formatBytes(memLimit)}</div>
+        <div class="w-full bg-gray-700 rounded-full h-1.5 mt-1">
+            <div class="${barColor} h-1.5 rounded-full" style="width: ${Math.min(pct, 100)}%"></div>
+        </div>
+    `;
+}
+
+let currentFilter = 'all';
+let containerList = [];
+let initialLoadComplete = false;
+let previousNetworkStats = {};
+let lastFetchTime = null;
+let statsLoading = false;
+
+function getContainerListEl() {
+    return document.getElementById('container-list');
+}
+
+function findContainerRow(containerId) {
+    const list = getContainerListEl();
+    if (!list) return null;
+    const id = String(containerId);
+    return Array.from(list.querySelectorAll('tr[data-container-id]')).find((row) => row.dataset.containerId === id) || null;
+}
+
+function getContainerNameById(id) {
+    const containerId = String(id);
+    const cached = containerList.find((item) => String(item.id) === containerId);
+    if (cached) return cached.name || containerId;
+
+    const row = findContainerRow(containerId);
+    return row ? (row.dataset.containerName || containerId) : containerId;
+}
+
+function getWebUIPort(container) {
+    if (!container.ports || container.ports.length === 0) return null;
+
+    const tcpPorts = container.ports.filter((port) => port.protocol !== 'udp');
+    const hostTcp = tcpPorts.find((port) => port.host_port);
+    const anyHost = container.ports.find((port) => port.host_port);
+    const tcpContainer = tcpPorts.find((port) => port.container_port);
+    const fallback = container.ports.find((port) => port.container_port);
+
+    const candidate = hostTcp?.host_port || anyHost?.host_port || tcpContainer?.container_port || fallback?.container_port;
+    const port = Number(candidate);
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+    return port;
+}
+
+function calculateNetworkRate(containerId, currentRx, currentTx) {
+    const rx = Number(currentRx);
+    const tx = Number(currentTx);
+    if (!Number.isFinite(rx) || !Number.isFinite(tx)) {
+        return null;
+    }
+
+    const now = Date.now();
+    const key = String(containerId);
+    const prev = previousNetworkStats[key];
+
+    if (!prev || !lastFetchTime) {
+        previousNetworkStats[key] = { rx, tx };
+        return null;
+    }
+
+    const timeDelta = (now - lastFetchTime) / 1000;
+    if (timeDelta <= 0) return null;
+
+    const rxRate = Math.max(0, (rx - prev.rx) / timeDelta);
+    const txRate = Math.max(0, (tx - prev.tx) / timeDelta);
+
+    previousNetworkStats[key] = { rx, tx };
+    return { rxRate, txRate };
+}
+
+function formatNetworkCell(rx, tx, containerId, loading = false) {
+    if (loading) return loadingSpinner();
+
+    const rxValue = Number(rx);
+    const txValue = Number(tx);
+    if (!Number.isFinite(rxValue) || !Number.isFinite(txValue)) {
+        return '<span class="text-gray-500">—</span>';
+    }
+
+    const rates = containerId ? calculateNetworkRate(containerId, rxValue, txValue) : null;
+    if (rates) {
+        return `<span class="text-blue-300">↓${formatBytes(rates.rxRate)}/s</span><br><span class="text-green-300">↑${formatBytes(rates.txRate)}/s</span>`;
+    }
+
+    return `<span class="text-blue-300">↓${formatBytes(rxValue)}</span><br><span class="text-green-300">↑${formatBytes(txValue)}</span>`;
+}
+
+function clearContainerList() {
+    const list = getContainerListEl();
+    if (!list) return;
+    list.textContent = '';
+}
+
+function appendTableMessage(message, className = '') {
+    const list = getContainerListEl();
+    if (!list) return;
+
+    clearContainerList();
+
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 8;
+    cell.className = `text-center py-4 ${className}`.trim();
+    cell.textContent = message;
+    row.appendChild(cell);
+    list.appendChild(row);
+}
+
+function renderContainerNameCell(cell, container) {
+    cell.textContent = '';
+    cell.appendChild(document.createTextNode(container.name || 'Unnamed'));
+
+    if (container.update_available) {
+        const indicator = document.createElement('span');
+        indicator.className = 'ml-1 text-yellow-400';
+        indicator.title = 'Update available';
+        indicator.textContent = '↻';
+        cell.appendChild(indicator);
+    }
+}
+
+function createStatusBadge(status) {
+    const normalized = status || 'unknown';
+    const statusClass = normalized === 'running' ? 'status-running' : normalized === 'stopped' ? 'status-stopped' : 'status-other';
+
+    const badge = document.createElement('span');
+    badge.className = `px-2 py-1 text-white rounded ${statusClass}`;
+    badge.textContent = normalized;
+    return badge;
+}
+
+function buildActionButton({ label, action, containerId, disabled = false, className }) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.action = action;
+    button.dataset.containerId = String(containerId);
+    button.className = className;
+    button.textContent = label;
+    button.disabled = disabled;
+
+    if (disabled) {
+        button.classList.add('opacity-50', 'cursor-not-allowed');
+    }
+
+    return button;
+}
+
+function buildMenuButton({ label, action, containerId, roundedClass }) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.dataset.menuAction = action;
+    button.dataset.containerId = String(containerId);
+    button.className = `w-full text-left px-3 py-2 text-xs hover:bg-gray-600 text-white ${roundedClass}`.trim();
+    button.textContent = label;
+    return button;
+}
+
+function buildUnavailableRow(container) {
+    const row = document.createElement('tr');
+    row.dataset.containerId = String(container.id || 'unavailable');
+    row.dataset.containerName = container.name || 'Docker';
+
+    const nameCell = document.createElement('td');
+    nameCell.className = 'px-6 py-4 whitespace-nowrap text-sm font-medium';
+    nameCell.textContent = container.name || 'Docker unavailable';
+    row.appendChild(nameCell);
+
+    const imageCell = document.createElement('td');
+    imageCell.className = 'px-6 py-4 whitespace-nowrap text-sm';
+    imageCell.textContent = container.image || 'N/A';
+    row.appendChild(imageCell);
+
+    const statusCell = document.createElement('td');
+    statusCell.className = 'px-6 py-4 whitespace-nowrap';
+    statusCell.appendChild(createStatusBadge(container.status || 'unavailable'));
+    row.appendChild(statusCell);
+
+    for (let i = 0; i < 3; i += 1) {
+        const cell = document.createElement('td');
+        cell.className = 'px-4 py-4 whitespace-nowrap text-sm text-gray-500';
+        cell.textContent = '—';
+        row.appendChild(cell);
+    }
+
+    const webCell = document.createElement('td');
+    webCell.className = 'px-6 py-4 whitespace-nowrap text-sm';
+    webCell.textContent = 'N/A';
+    row.appendChild(webCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'px-4 py-4 whitespace-nowrap text-sm text-gray-500';
+    actionsCell.textContent = '—';
+    row.appendChild(actionsCell);
+
+    return row;
+}
+
+function buildContainerRow(container, showStatsLoading = false) {
+    const row = document.createElement('tr');
+    row.dataset.containerId = String(container.id);
+    row.dataset.containerName = container.name || String(container.id);
+
+    const isRunning = container.status === 'running';
+    const hasStats = container.cpu_percent !== null && container.cpu_percent !== undefined;
+    const loading = showStatsLoading && isRunning && !hasStats;
+
+    const nameCell = document.createElement('td');
+    nameCell.className = 'px-6 py-4 whitespace-nowrap text-sm font-medium';
+    nameCell.dataset.cell = 'name';
+    renderContainerNameCell(nameCell, container);
+    row.appendChild(nameCell);
+
+    const imageCell = document.createElement('td');
+    imageCell.className = 'px-6 py-4 whitespace-nowrap text-sm text-gray-400 max-w-xs truncate';
+    imageCell.title = container.image || '';
+    imageCell.textContent = container.image || '—';
+    row.appendChild(imageCell);
+
+    const statusCell = document.createElement('td');
+    statusCell.className = 'px-6 py-4 whitespace-nowrap';
+    statusCell.dataset.cell = 'status';
+    statusCell.appendChild(createStatusBadge(container.status));
+    row.appendChild(statusCell);
+
+    const cpuCell = document.createElement('td');
+    cpuCell.className = 'px-4 py-4 whitespace-nowrap text-sm';
+    cpuCell.dataset.stat = 'cpu';
+    cpuCell.innerHTML = formatCpuCell(container.cpu_percent, loading);
+    row.appendChild(cpuCell);
+
+    const memoryCell = document.createElement('td');
+    memoryCell.className = 'px-4 py-4 whitespace-nowrap text-sm';
+    memoryCell.dataset.stat = 'memory';
+    memoryCell.innerHTML = formatMemoryCell(container.memory_percent, container.memory_used, container.memory_limit, loading);
+    row.appendChild(memoryCell);
+
+    const networkCell = document.createElement('td');
+    networkCell.className = 'px-4 py-4 whitespace-nowrap text-sm';
+    networkCell.dataset.stat = 'network';
+    networkCell.innerHTML = formatNetworkCell(container.net_rx, container.net_tx, container.id, loading);
+    row.appendChild(networkCell);
+
+    const webCell = document.createElement('td');
+    webCell.className = 'px-4 py-4 whitespace-nowrap text-sm';
+    const webPort = getWebUIPort(container);
+    if (webPort) {
+        const link = document.createElement('a');
+        link.href = `http://${window.location.hostname}:${webPort}`;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.className = 'text-blue-500 hover:text-blue-400 underline';
+        link.textContent = 'Open';
+        webCell.appendChild(link);
+    } else {
+        webCell.textContent = 'N/A';
+    }
+    row.appendChild(webCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'px-4 py-4 whitespace-nowrap text-sm';
+
+    const actionWrap = document.createElement('div');
+    actionWrap.className = 'flex items-center gap-1';
+
+    actionWrap.appendChild(buildActionButton({
+        label: 'Start',
+        action: 'start',
+        containerId: container.id,
+        disabled: container.status === 'running',
+        className: 'action-btn bg-green-700 hover:bg-green-600 text-white py-1 px-2 rounded text-xs',
+    }));
+
+    actionWrap.appendChild(buildActionButton({
+        label: 'Stop',
+        action: 'stop',
+        containerId: container.id,
+        disabled: ['stopped', 'exited'].includes(container.status),
+        className: 'action-btn bg-yellow-700 hover:bg-yellow-600 text-white py-1 px-2 rounded text-xs',
+    }));
+
+    actionWrap.appendChild(buildActionButton({
+        label: 'Restart',
+        action: 'restart',
+        containerId: container.id,
+        className: 'action-btn bg-blue-700 hover:bg-blue-600 text-white py-1 px-2 rounded text-xs',
+    }));
+
+    const dropdownWrap = document.createElement('div');
+    dropdownWrap.className = 'relative';
+    dropdownWrap.dataset.dropdownContainer = String(container.id);
+
+    const dropdownToggle = document.createElement('button');
+    dropdownToggle.type = 'button';
+    dropdownToggle.className = 'bg-gray-600 hover:bg-gray-500 text-white py-1 px-2 rounded text-xs';
+    dropdownToggle.dataset.dropdownToggle = String(container.id);
+    dropdownToggle.dataset.containerId = String(container.id);
+    dropdownToggle.textContent = '⋮';
+    dropdownWrap.appendChild(dropdownToggle);
+
+    const dropdownMenu = document.createElement('div');
+    dropdownMenu.className = 'dropdown-menu hidden absolute mt-1 w-36 bg-gray-700 rounded shadow-lg z-50 border border-gray-600';
+    dropdownMenu.dataset.dropdownMenu = String(container.id);
+    dropdownMenu.dataset.dropdownMenuFor = String(container.id);
+    dropdownMenu.appendChild(buildMenuButton({ label: 'Check Update', action: 'check_update', containerId: container.id, roundedClass: 'rounded-t' }));
+    dropdownMenu.appendChild(buildMenuButton({ label: 'Update', action: 'update', containerId: container.id, roundedClass: '' }));
+    dropdownMenu.appendChild(buildMenuButton({ label: 'Logs', action: 'logs', containerId: container.id, roundedClass: '' }));
+    dropdownMenu.appendChild(buildMenuButton({ label: 'Network Test', action: 'network-test', containerId: container.id, roundedClass: 'rounded-b' }));
+    dropdownWrap.appendChild(dropdownMenu);
+
+    actionWrap.appendChild(dropdownWrap);
+    actionsCell.appendChild(actionWrap);
+    row.appendChild(actionsCell);
+
+    return row;
+}
+
+function hasContainerListChanged(oldList, newList) {
+    if (oldList.length !== newList.length) return true;
+    const oldIds = new Set(oldList.map((container) => String(container.id)));
+    const newIds = new Set(newList.map((container) => String(container.id)));
+    for (const id of newIds) {
+        if (!oldIds.has(id)) return true;
+    }
+    return false;
+}
+
+function closeAllDropdowns(exceptId = null) {
+    document.querySelectorAll('[data-dropdown-menu-for]').forEach((menu) => {
+        if (exceptId !== null && menu.dataset.dropdownMenuFor === String(exceptId)) {
+            return;
+        }
+        menu.classList.add('hidden');
+    });
+}
+
+function toggleDropdown(containerId) {
+    const row = findContainerRow(containerId);
+    if (!row) return;
+
+    const menu = row.querySelector('[data-dropdown-menu-for]');
+    if (!menu) return;
+
+    const willOpen = menu.classList.contains('hidden');
+    closeAllDropdowns();
+    if (willOpen) {
+        menu.classList.remove('hidden');
+    }
+}
+
+function closeDropdown(containerId) {
+    const row = findContainerRow(containerId);
+    if (!row) return;
+
+    const menu = row.querySelector('[data-dropdown-menu-for]');
+    if (menu) {
+        menu.classList.add('hidden');
+    }
+}
+
+function updateActionButtons(row, container) {
+    const startBtn = row.querySelector('button[data-action="start"]');
+    const stopBtn = row.querySelector('button[data-action="stop"]');
+
+    if (startBtn) {
+        const disabled = container.status === 'running';
+        startBtn.disabled = disabled;
+        startBtn.classList.toggle('opacity-50', disabled);
+        startBtn.classList.toggle('cursor-not-allowed', disabled);
+    }
+
+    if (stopBtn) {
+        const disabled = ['stopped', 'exited'].includes(container.status);
+        stopBtn.disabled = disabled;
+        stopBtn.classList.toggle('opacity-50', disabled);
+        stopBtn.classList.toggle('cursor-not-allowed', disabled);
+    }
+}
+
+function updateContainerRows() {
+    containerList.forEach((container) => {
+        const row = findContainerRow(container.id);
+        if (!row) return;
+
+        row.dataset.containerName = container.name || String(container.id);
+
+        const statusCell = row.querySelector('[data-cell="status"]');
+        if (statusCell) {
+            statusCell.textContent = '';
+            statusCell.appendChild(createStatusBadge(container.status));
         }
 
-        // Format bytes to human readable
-        function formatBytes(bytes) {
-            if (bytes === null || bytes === undefined) return '—';
-            if (bytes === 0) return '0 B';
-            const k = 1024;
-            const sizes = ['B', 'KB', 'MB', 'GB'];
-            const i = Math.floor(Math.log(bytes) / Math.log(k));
-            return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+        const nameCell = row.querySelector('[data-cell="name"]');
+        if (nameCell) {
+            renderContainerNameCell(nameCell, container);
         }
 
-        // Get color class based on percentage
-        function getStatColorClass(percent) {
-            if (percent === null || percent === undefined) return 'text-gray-500';
-            if (percent < 50) return 'text-green-400';
-            if (percent < 80) return 'text-yellow-400';
-            return 'text-red-400';
+        const cpuCell = row.querySelector('td[data-stat="cpu"]');
+        if (cpuCell) {
+            cpuCell.innerHTML = formatCpuCell(container.cpu_percent);
         }
 
-        // Loading spinner HTML
-        function loadingSpinner() {
-            return '<div class="loading-spinner"></div>';
+        const memoryCell = row.querySelector('td[data-stat="memory"]');
+        if (memoryCell) {
+            memoryCell.innerHTML = formatMemoryCell(container.memory_percent, container.memory_used, container.memory_limit);
         }
 
-        // Format stats display with mini progress bars
-        function formatCpuCell(cpuPercent, loading = false) {
-            if (loading) return loadingSpinner();
-            if (cpuPercent === null || cpuPercent === undefined) return '<span class="text-gray-500">—</span>';
-            const colorClass = getStatColorClass(cpuPercent);
-            const barColor = cpuPercent < 50 ? 'bg-green-500' : cpuPercent < 80 ? 'bg-yellow-500' : 'bg-red-500';
-            return `
-                <span class="${colorClass} text-sm">${cpuPercent.toFixed(1)}%</span>
-                <div class="w-full bg-gray-700 rounded-full h-1.5 mt-1">
-                    <div class="${barColor} h-1.5 rounded-full" style="width: ${Math.min(cpuPercent, 100)}%"></div>
-                </div>`;
+        const networkCell = row.querySelector('td[data-stat="network"]');
+        if (networkCell) {
+            networkCell.innerHTML = formatNetworkCell(container.net_rx, container.net_tx, container.id);
         }
 
-        function formatMemoryCell(memPercent, memUsed, memLimit, loading = false) {
-            if (loading) return loadingSpinner();
-            if (memPercent === null || memPercent === undefined) return '<span class="text-gray-500">—</span>';
-            const colorClass = getStatColorClass(memPercent);
-            const barColor = memPercent < 50 ? 'bg-green-500' : memPercent < 80 ? 'bg-yellow-500' : 'bg-red-500';
-            return `
-                <span class="${colorClass} text-sm">${memPercent.toFixed(1)}%</span>
-                <div class="text-xs text-gray-400">${formatBytes(memUsed)} / ${formatBytes(memLimit)}</div>
-                <div class="w-full bg-gray-700 rounded-full h-1.5 mt-1">
-                    <div class="${barColor} h-1.5 rounded-full" style="width: ${Math.min(memPercent, 100)}%"></div>
-                </div>`;
+        updateActionButtons(row, container);
+    });
+}
+
+function renderContainers(showStatsLoading = false) {
+    const list = getContainerListEl();
+    if (!list) return;
+
+    clearContainerList();
+
+    const filteredContainers = containerList.filter((container) => {
+        if (currentFilter === 'all') return true;
+        return container.status === currentFilter;
+    });
+
+    if (filteredContainers.length === 0) {
+        appendTableMessage(`No ${currentFilter} containers found`);
+        return;
+    }
+
+    if (
+        filteredContainers.length === 1 &&
+        (filteredContainers[0].status === 'unavailable' || filteredContainers[0].status === 'error')
+    ) {
+        list.appendChild(buildUnavailableRow(filteredContainers[0]));
+        return;
+    }
+
+    filteredContainers.forEach((container) => {
+        list.appendChild(buildContainerRow(container, showStatsLoading));
+    });
+}
+
+async function fetchDockerContainers(forceFullRender = false, includeStats = false) {
+    const lastUpdatedEl = document.getElementById('last-updated');
+
+    if (!initialLoadComplete) {
+        appendTableMessage('Loading...');
+    }
+
+    try {
+        const statsParam = includeStats ? 'true' : 'false';
+        const newContainerList = await requestApiJson(`/api/containers?stats=${statsParam}`);
+        if (lastUpdatedEl) {
+            lastUpdatedEl.textContent = `Last updated: ${formatDateTime(new Date())}`;
         }
 
-        // Calculate network rate (bytes/sec) from cumulative values
-        function calculateNetworkRate(containerId, currentRx, currentTx) {
-            const now = Date.now();
-            const prev = previousNetworkStats[containerId];
+        const needsFullRender =
+            forceFullRender ||
+            !initialLoadComplete ||
+            hasContainerListChanged(containerList, newContainerList);
 
-            if (!prev || !lastFetchTime) {
-                // First fetch - store values and return null (will show cumulative)
-                previousNetworkStats[containerId] = { rx: currentRx, tx: currentTx };
-                return null;
-            }
+        containerList = newContainerList;
 
-            const timeDelta = (now - lastFetchTime) / 1000; // seconds
-            if (timeDelta <= 0) return null;
-
-            const rxRate = Math.max(0, (currentRx - prev.rx) / timeDelta);
-            const txRate = Math.max(0, (currentTx - prev.tx) / timeDelta);
-
-            // Update stored values
-            previousNetworkStats[containerId] = { rx: currentRx, tx: currentTx };
-
-            return { rxRate, txRate };
+        if (needsFullRender) {
+            renderContainers(!includeStats);
+        } else {
+            updateContainerRows();
         }
 
-        function formatNetworkCell(rx, tx, containerId, loading = false) {
-            if (loading) return loadingSpinner();
-            if (rx === null || rx === undefined) return '<span class="text-gray-500">—</span>';
+        lastFetchTime = Date.now();
 
-            const rates = containerId ? calculateNetworkRate(containerId, rx, tx) : null;
+        initialLoadComplete = true;
 
-            if (rates) {
-                return `<span class="text-blue-300">↓${formatBytes(rates.rxRate)}/s</span><br><span class="text-green-300">↑${formatBytes(rates.txRate)}/s</span>`;
-            }
-            // First fetch - show cumulative with indicator
-            return `<span class="text-blue-300">↓${formatBytes(rx)}</span><br><span class="text-green-300">↑${formatBytes(tx)}</span>`;
+        if (!includeStats) {
+            fetchContainerStats();
         }
-
-        // Show notification function (uses shared toast system from api.js)
-        function showNotification(message, type = 'info') {
-            showToast(message, type);
+    } catch (error) {
+        console.error('Error fetching Docker containers:', error);
+        if (!initialLoadComplete) {
+            appendTableMessage('Error loading containers', 'text-red-500');
         }
+        showNotification('Error fetching containers', 'error');
+    }
+}
 
-        // Filter state
-        let currentFilter = 'all';
+async function fetchContainerStats() {
+    const runningContainers = containerList.filter((container) => container.status === 'running');
+    if (runningContainers.length === 0) return;
 
-        // Store the container list
-        let containerList = [];
+    statsLoading = true;
+    const ids = runningContainers.map((container) => container.id).join(',');
 
-        // Track if initial load has completed
-        let initialLoadComplete = false;
+    try {
+        const stats = await requestApiJson(`/api/containers/stats?ids=${encodeURIComponent(ids)}`);
 
-        // Track previous network stats for rate calculation
-        let previousNetworkStats = {};
-        let lastFetchTime = null;
-
-        function getContainerNameById(id) {
-            const cached = containerList.find(c => c.id === id);
-            if (cached) return cached.name;
-
-            const row = document.querySelector(`tr[data-container-id="${id}"]`);
-            return row ? row.getAttribute('data-container-name') : id;
-        }
-
-        function getWebUIPort(container) {
-            if (!container.ports || container.ports.length === 0) {
-                return null;
-            }
-
-            const tcpPorts = container.ports.filter(port => port.protocol !== 'udp');
-
-            const hostTcp = tcpPorts.find(port => port.host_port);
-            if (hostTcp) {
-                return hostTcp.host_port;
-            }
-
-            const anyHost = container.ports.find(port => port.host_port);
-            if (anyHost) {
-                return anyHost.host_port;
-            }
-
-            const tcpContainer = tcpPorts.find(port => port.container_port);
-            if (tcpContainer) {
-                return tcpContainer.container_port;
-            }
-
-            const fallback = container.ports.find(port => port.container_port);
-            return fallback ? fallback.container_port : null;
-        }
-
-        // Track stats loading state
-        let statsLoading = false;
-
-        // Fetch Docker containers and update the table
-        async function fetchDockerContainers(forceFullRender = false, includeStats = false) {
-            const containerListEl = document.getElementById('container-list');
-            const lastUpdatedEl = document.getElementById('last-updated');
-
-            // Only show loading indicator on initial load
-            if (!initialLoadComplete) {
-                containerListEl.innerHTML = '<tr><td colspan="8" class="text-center py-4">Loading...</td></tr>';
-            }
-
-            try {
-                // First fetch: get containers without stats (fast)
-                const statsParam = includeStats ? 'true' : 'false';
-                const newContainerList = await requestApiJson(`/api/containers?stats=${statsParam}`);
-
-                // Update timestamp for network rate calculation
-                lastFetchTime = Date.now();
-
-                // Update last updated timestamp
-                const now = new Date();
-                lastUpdatedEl.textContent = `Last updated: ${formatDateTime(now)}`;
-
-                // Check if we need a full re-render or can do smart update
-                const needsFullRender = forceFullRender ||
-                    !initialLoadComplete ||
-                    hasContainerListChanged(containerList, newContainerList);
-
-                containerList = newContainerList;
-
-                if (needsFullRender) {
-                    renderContainers(!includeStats); // Pass true to show loading spinners
-                } else {
-                    updateContainerRows();
-                }
-
-                initialLoadComplete = true;
-
-                // Lazy load stats for running containers if not already included
-                if (!includeStats) {
-                    fetchContainerStats();
-                }
-            } catch (error) {
-                console.error('Error fetching Docker containers:', error);
-                if (!initialLoadComplete) {
-                    containerListEl.innerHTML = '<tr><td colspan="8" class="text-center py-4 text-red-500">Error loading containers</td></tr>';
-                }
-                showNotification('Error fetching containers', 'error');
-            }
-        }
-
-        // Fetch stats for running containers lazily
-        async function fetchContainerStats() {
-            const runningContainers = containerList.filter(c => c.status === 'running');
-            if (runningContainers.length === 0) return;
-
-            statsLoading = true;
-            const ids = runningContainers.map(c => c.id).join(',');
-
-            try {
-                const stats = await requestApiJson(`/api/containers/stats?ids=${ids}`);
-
-                // Update container list with stats
-                containerList.forEach(container => {
-                    const containerStats = stats[container.id];
-                    if (containerStats) {
-                        container.cpu_percent = containerStats.cpu_percent;
-                        container.memory_percent = containerStats.memory_percent;
-                        container.memory_used = containerStats.memory_used;
-                        container.memory_limit = containerStats.memory_limit;
-                        container.net_rx = containerStats.net_rx;
-                        container.net_tx = containerStats.net_tx;
-                    }
-                });
-
-                // Update the display
-                updateContainerRows();
-                lastFetchTime = Date.now();
-            } catch (error) {
-                console.error('Error fetching container stats:', error);
-            } finally {
-                statsLoading = false;
-            }
-        }
-
-        // Check if container list has structurally changed (added/removed containers)
-        function hasContainerListChanged(oldList, newList) {
-            if (oldList.length !== newList.length) return true;
-            const oldIds = new Set(oldList.map(c => c.id));
-            const newIds = new Set(newList.map(c => c.id));
-            for (const id of newIds) {
-                if (!oldIds.has(id)) return true;
-            }
-            return false;
-        }
-
-        // Update existing rows in-place without destroying DOM
-        function updateContainerRows() {
-            containerList.forEach(container => {
-                const row = document.querySelector(`tr[data-container-id="${container.id}"]`);
-                if (!row) return;
-
-                // Update status badge
-                const statusCell = row.querySelector('td:nth-child(3)');
-                if (statusCell) {
-                    const statusClass = container.status === 'running' ? 'status-running' :
-                        container.status === 'stopped' ? 'status-stopped' : 'status-other';
-                    statusCell.innerHTML = `
-                        <span class="px-2 py-1 text-white rounded ${statusClass}">
-                            ${container.status}
-                        </span>
-                    `;
-                }
-
-                // Update name cell (for update indicator)
-                const nameCell = row.querySelector('td:nth-child(1)');
-                if (nameCell) {
-                    nameCell.innerHTML = `${container.name}${container.update_available ? '<span class="ml-1 text-yellow-400" title="Update available">&#x21bb;</span>' : ''}`;
-                }
-
-                // Update stats cells
-                const cpuCell = row.querySelector('td[data-stat="cpu"]');
-                if (cpuCell) {
-                    cpuCell.innerHTML = formatCpuCell(container.cpu_percent);
-                }
-
-                const memoryCell = row.querySelector('td[data-stat="memory"]');
-                if (memoryCell) {
-                    memoryCell.innerHTML = formatMemoryCell(container.memory_percent, container.memory_used, container.memory_limit);
-                }
-
-                const networkCell = row.querySelector('td[data-stat="network"]');
-                if (networkCell) {
-                    networkCell.innerHTML = formatNetworkCell(container.net_rx, container.net_tx, container.id);
-                }
-
-                // Update button states
-                const startBtn = row.querySelector('button[data-action="start"]');
-                const stopBtn = row.querySelector('button[data-action="stop"]');
-
-                if (startBtn) {
-                    startBtn.disabled = container.status === 'running';
-                    startBtn.classList.toggle('opacity-50', container.status === 'running');
-                    startBtn.classList.toggle('cursor-not-allowed', container.status === 'running');
-                }
-
-                if (stopBtn) {
-                    const isStopped = ['stopped', 'exited'].includes(container.status);
-                    stopBtn.disabled = isStopped;
-                    stopBtn.classList.toggle('opacity-50', isStopped);
-                    stopBtn.classList.toggle('cursor-not-allowed', isStopped);
-                }
-            });
-        }
-
-        // Render containers based on filter
-        function renderContainers(showStatsLoading = false) {
-            const containerListEl = document.getElementById('container-list');
-            containerListEl.innerHTML = '';
-
-            // Filter containers based on current filter
-            const filteredContainers = containerList.filter(container => {
-                if (currentFilter === 'all') return true;
-                return container.status === currentFilter;
-            });
-
-            if (filteredContainers.length === 0) {
-                containerListEl.innerHTML = `<tr><td colspan="8" class="text-center py-4">No ${currentFilter} containers found</td></tr>`;
-                return;
-            }
-
-            // Special case for when Docker is not available
-            if (filteredContainers.length === 1 &&
-                (filteredContainers[0].status === 'unavailable' || filteredContainers[0].status === 'error')) {
-                const row = `
-                    <tr data-container-id="${filteredContainers[0].id}" data-container-name="${filteredContainers[0].name}">
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">${filteredContainers[0].name}</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">${filteredContainers[0].image}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="px-2 py-1 text-white rounded status-other">
-                                ${filteredContainers[0].status}
-                            </span>
-                        </td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">—</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">—</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500">—</td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm">N/A</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm">—</td>
-                    </tr>
-                `;
-                containerListEl.innerHTML = row;
-                return;
-            }
-
-            // Create rows for each container
-            filteredContainers.forEach(container => {
-                const statusClass = container.status === 'running' ? 'status-running' :
-                    container.status === 'stopped' ? 'status-stopped' : 'status-other';
-
-                // Show loading spinners for running containers that don't have stats yet
-                const isRunning = container.status === 'running';
-                const hasStats = container.cpu_percent !== null && container.cpu_percent !== undefined;
-                const loading = showStatsLoading && isRunning && !hasStats;
-
-                // Determine if the container has a Web UI
-                const port = getWebUIPort(container);
-                const webUILink = port
-                    ? `<a href="http://${window.location.hostname}:${port}" target="_blank" class="text-blue-500 hover:text-blue-400 underline">Open</a>`
-                    : 'N/A';
-
-                const row = `
-                    <tr data-container-id="${container.id}" data-container-name="${container.name}">
-                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                            ${container.name}
-                            ${container.update_available ? '<span class="ml-1 text-yellow-400" title="Update available">&#x21bb;</span>' : ''}
-                        </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-400 max-w-xs truncate" title="${container.image}">${container.image}</td>
-                        <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="px-2 py-1 text-white rounded ${statusClass}">
-                                ${container.status}
-                            </span>
-                        </td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm" data-stat="cpu">${formatCpuCell(container.cpu_percent, loading)}</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm" data-stat="memory">${formatMemoryCell(container.memory_percent, container.memory_used, container.memory_limit, loading)}</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm" data-stat="network">${formatNetworkCell(container.net_rx, container.net_tx, container.id, loading)}</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm">${webUILink}</td>
-                        <td class="px-4 py-4 whitespace-nowrap text-sm">
-                            <div class="flex items-center gap-1">
-                                <button data-action="start" class="action-btn bg-green-700 hover:bg-green-600 text-white py-1 px-2 rounded text-xs ${container.status === 'running' ? 'opacity-50 cursor-not-allowed' : ''}"
-                                        onclick="controlContainer('${container.id}', 'start')"
-                                        ${container.status === 'running' ? 'disabled' : ''}>Start</button>
-                                <button data-action="stop" class="action-btn bg-yellow-700 hover:bg-yellow-600 text-white py-1 px-2 rounded text-xs ${['stopped', 'exited'].includes(container.status) ? 'opacity-50 cursor-not-allowed' : ''}"
-                                        onclick="controlContainer('${container.id}', 'stop')"
-                                        ${['stopped', 'exited'].includes(container.status) ? 'disabled' : ''}>Stop</button>
-                                <button data-action="restart" class="action-btn bg-blue-700 hover:bg-blue-600 text-white py-1 px-2 rounded text-xs"
-                                        onclick="controlContainer('${container.id}', 'restart')">Restart</button>
-                                <div class="relative">
-                                    <button class="bg-gray-600 hover:bg-gray-500 text-white py-1 px-2 rounded text-xs"
-                                            onclick="toggleDropdown('${container.id}')">⋮</button>
-                                    <div id="dropdown-${container.id}" class="dropdown-menu hidden absolute mt-1 w-36 bg-gray-700 rounded shadow-lg z-50 border border-gray-600">
-                                        <button class="w-full text-left px-3 py-2 text-xs hover:bg-gray-600 text-white rounded-t"
-                                                onclick="controlContainer('${container.id}', 'check_update'); closeDropdown('${container.id}')">Check Update</button>
-                                        <button class="w-full text-left px-3 py-2 text-xs hover:bg-gray-600 text-white"
-                                                onclick="controlContainer('${container.id}', 'update'); closeDropdown('${container.id}')">Update</button>
-                                        <button class="w-full text-left px-3 py-2 text-xs hover:bg-gray-600 text-white"
-                                                onclick="viewLogs('${container.id}'); closeDropdown('${container.id}')">Logs</button>
-                                        <button class="w-full text-left px-3 py-2 text-xs hover:bg-gray-600 text-white rounded-b"
-                                                onclick="openContainerNetworkTest('${container.id}'); closeDropdown('${container.id}')">Network Test</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                `;
-                containerListEl.innerHTML += row;
-            });
-        }
-
-        // Toggle dropdown menu
-        function toggleDropdown(containerId) {
-            // Close all other dropdowns first
-            document.querySelectorAll('[id^="dropdown-"]').forEach(el => {
-                if (el.id !== `dropdown-${containerId}`) {
-                    el.classList.add('hidden');
-                }
-            });
-            const dropdown = document.getElementById(`dropdown-${containerId}`);
-            dropdown.classList.toggle('hidden');
-        }
-
-        function closeDropdown(containerId) {
-            document.getElementById(`dropdown-${containerId}`).classList.add('hidden');
-        }
-
-        // Close dropdowns when clicking outside
-        document.addEventListener('click', (e) => {
-            if (!e.target.closest('[id^="dropdown-"]') && !e.target.closest('button')) {
-                document.querySelectorAll('[id^="dropdown-"]').forEach(el => el.classList.add('hidden'));
-            }
+        containerList.forEach((container) => {
+            const containerStats = stats[container.id];
+            if (!containerStats) return;
+            container.cpu_percent = containerStats.cpu_percent;
+            container.memory_percent = containerStats.memory_percent;
+            container.memory_used = containerStats.memory_used;
+            container.memory_limit = containerStats.memory_limit;
+            container.net_rx = containerStats.net_rx;
+            container.net_tx = containerStats.net_tx;
         });
 
-        // Control Docker container (start/stop/restart)
-        async function controlContainer(id, action) {
-            const containerRow = document.querySelector(`tr[data-container-id="${id}"]`);
-            const containerName = containerRow ? containerRow.getAttribute('data-container-name') : id;
+        updateContainerRows();
+        lastFetchTime = Date.now();
+    } catch (error) {
+        console.error('Error fetching container stats:', error);
+    } finally {
+        statsLoading = false;
+    }
+}
 
-            // Show loading state on the button
-            let actionBtn = null;
-            let originalText = '';
-            if (containerRow) {
-                actionBtn = containerRow.querySelector(`button[data-action="${action}"]`);
-                if (actionBtn) {
-                    originalText = actionBtn.textContent;
-                    actionBtn.disabled = true;
-                    actionBtn.classList.add('opacity-75');
-                    actionBtn.textContent = '...';
-                }
-            }
+async function controlContainer(id, action) {
+    const containerId = String(id);
+    const containerRow = findContainerRow(containerId);
+    const containerName = containerRow ? (containerRow.dataset.containerName || containerId) : containerId;
 
-            // Show toast immediately so user knows action started
-            const actionNames = {
-                'start': 'Starting',
-                'stop': 'Stopping',
-                'restart': 'Restarting',
-                'check_update': 'Checking',
-                'update': 'Updating'
-            };
-            showNotification(`${actionNames[action] || action} ${containerName}...`, 'info');
-
-            try {
-                const result = await requestApiJson(`/api/containers/${id}/${action}`, { method: 'POST' });
-                if (result.error) {
-                    showNotification(`Error: ${result.error}`, 'error');
-                } else {
-                    let message = `${containerName} ${action}ed successfully`;
-                    if (action === 'check_update') {
-                        message = result.update_available
-                            ? `${containerName}: Update available!`
-                            : `${containerName}: Up to date`;
-                    }
-                    if (action === 'update') message = `${containerName} update triggered`;
-                    showNotification(message, 'success');
-                }
-
-                // Refresh container status
-                if (containerRow) {
-                    await updateContainerStatus(id);
-                } else {
-                    await fetchDockerContainers(true);
-                }
-            } catch (error) {
-                console.error(`Error controlling container ${id}:`, error);
-                showNotification(`Error ${action}ing container: ${error.message}`, 'error');
-            } finally {
-                // Reset button state
-                if (actionBtn) {
-                    actionBtn.disabled = false;
-                    actionBtn.classList.remove('opacity-75');
-                    actionBtn.textContent = originalText;
-                }
-            }
+    let actionBtn = null;
+    let originalText = '';
+    if (containerRow) {
+        actionBtn = containerRow.querySelector(`button[data-action="${action}"]`);
+        if (actionBtn) {
+            originalText = actionBtn.textContent || '';
+            actionBtn.disabled = true;
+            actionBtn.classList.add('opacity-75');
+            actionBtn.textContent = '...';
         }
-        
-        // Update a single container's status
-        async function updateContainerStatus(id) {
-            try {
-                const containers = await requestApiJson('/api/containers');
-                lastFetchTime = Date.now();
-                const container = containers.find(c => c.id === id);
-                
-                if (container && document.querySelector(`tr[data-container-id="${id}"]`)) {
-                    const row = document.querySelector(`tr[data-container-id="${id}"]`);
-                    const nameCell = row.querySelector('td:nth-child(1)');
-                    const statusCell = row.querySelector('td:nth-child(3)');
-                    
-                    const statusClass = container.status === 'running' ? 'status-running' :
-                        container.status === 'stopped' ? 'status-stopped' : 'status-other';
-                    
-                    nameCell.innerHTML = `${container.name}${container.update_available ? '<span class="ml-1 text-yellow-400" title="Update available">&#x21bb;</span>' : ''}`;
+    }
 
-                    statusCell.innerHTML = `
-                        <span class="px-2 py-1 text-white rounded ${statusClass}">
-                            ${container.status}
-                        </span>
-                    `;
+    const actionNames = {
+        start: 'Starting',
+        stop: 'Stopping',
+        restart: 'Restarting',
+        check_update: 'Checking',
+        update: 'Updating',
+    };
+    showNotification(`${actionNames[action] || action} ${containerName}...`, 'info');
 
-                    // Update stats cells
-                    const cpuCell = row.querySelector('td[data-stat="cpu"]');
-                    if (cpuCell) cpuCell.innerHTML = formatCpuCell(container.cpu_percent);
+    try {
+        const encodedId = encodeURIComponent(containerId);
+        const result = await requestApiJson(`/api/containers/${encodedId}/${action}`, { method: 'POST' });
 
-                    const memoryCell = row.querySelector('td[data-stat="memory"]');
-                    if (memoryCell) memoryCell.innerHTML = formatMemoryCell(container.memory_percent, container.memory_used, container.memory_limit);
+        if (result.error) {
+            showNotification(`Error: ${result.error}`, 'error');
+        } else {
+            let message = `${containerName} ${action}ed successfully`;
+            if (action === 'check_update') {
+                message = result.update_available ? `${containerName}: Update available!` : `${containerName}: Up to date`;
+            }
+            if (action === 'update') {
+                message = `${containerName} update triggered`;
+            }
+            showNotification(message, 'success');
+        }
 
-                    const networkCell = row.querySelector('td[data-stat="network"]');
-                    if (networkCell) networkCell.innerHTML = formatNetworkCell(container.net_rx, container.net_tx, container.id);
+        if (containerRow) {
+            await updateContainerStatus(containerId);
+        } else {
+            await fetchDockerContainers(true);
+        }
+    } catch (error) {
+        console.error(`Error controlling container ${containerId}:`, error);
+        showNotification(`Error ${action}ing container: ${error.message}`, 'error');
+    } finally {
+        if (actionBtn) {
+            actionBtn.disabled = false;
+            actionBtn.classList.remove('opacity-75');
+            actionBtn.textContent = originalText;
+        }
+    }
+}
 
-                    // Update the container in our cached list
-                    for (let i = 0; i < containerList.length; i++) {
-                        if (containerList[i].id === id) {
-                            containerList[i] = container;
-                            break;
-                        }
-                    }
-                    
-                    // Re-render if filter might exclude this container now
-                    if (currentFilter !== 'all' && container.status !== currentFilter) {
-                        renderContainers();
-                    } else {
-                        // Just update button states
-                        const startButton = row.querySelector('button[data-action="start"]');
-                        const stopButton = row.querySelector('button[data-action="stop"]');
-                        const restartButton = row.querySelector('button[data-action="restart"]');
-                        const checkButton = row.querySelector('button[data-action="check_update"]');
-                        const updateButton = row.querySelector('button[data-action="update"]');
-                        const logsButton = row.querySelector('button[data-action="logs"]');
-                        const networkButton = row.querySelector('button[data-action="network-test"]');
+async function updateContainerStatus(id) {
+    const containerId = String(id);
 
-                        if (startButton) {
-                            startButton.disabled = container.status === 'running';
-                            startButton.classList.toggle('opacity-50', container.status === 'running');
-                            startButton.classList.toggle('cursor-not-allowed', container.status === 'running');
-                        }
-                        
-                        if (stopButton) {
-                            const isStopped = ['stopped', 'exited'].includes(container.status);
-                            stopButton.disabled = isStopped;
-                            stopButton.classList.toggle('opacity-50', isStopped);
-                            stopButton.classList.toggle('cursor-not-allowed', isStopped);
-                        }
+    try {
+        const containers = await requestApiJson('/api/containers');
+        const container = containers.find((item) => String(item.id) === containerId);
+        const row = findContainerRow(containerId);
 
-                        if (restartButton) restartButton.disabled = false;
-                        if (checkButton) checkButton.disabled = false;
-                        if (updateButton) updateButton.disabled = false;
-                        if (logsButton) logsButton.disabled = false;
-                        if (networkButton) networkButton.disabled = false;
-                    }
-                }
-            } catch (error) {
-                console.error(`Error updating container status:`, error);
-                showNotification('Error updating container status', 'error');
+        if (!container || !row) return;
+
+        row.dataset.containerName = container.name || containerId;
+
+        const nameCell = row.querySelector('[data-cell="name"]');
+        const statusCell = row.querySelector('[data-cell="status"]');
+        const cpuCell = row.querySelector('td[data-stat="cpu"]');
+        const memoryCell = row.querySelector('td[data-stat="memory"]');
+        const networkCell = row.querySelector('td[data-stat="network"]');
+
+        if (nameCell) renderContainerNameCell(nameCell, container);
+        if (statusCell) {
+            statusCell.textContent = '';
+            statusCell.appendChild(createStatusBadge(container.status));
+        }
+        if (cpuCell) cpuCell.innerHTML = formatCpuCell(container.cpu_percent);
+        if (memoryCell) memoryCell.innerHTML = formatMemoryCell(container.memory_percent, container.memory_used, container.memory_limit);
+        if (networkCell) networkCell.innerHTML = formatNetworkCell(container.net_rx, container.net_tx, container.id);
+
+        for (let i = 0; i < containerList.length; i += 1) {
+            if (String(containerList[i].id) === containerId) {
+                containerList[i] = container;
+                break;
             }
         }
 
-        async function viewLogs(id) {
-            const modal = document.getElementById('logs-modal');
-            const content = document.getElementById('logs-content');
-            const title = document.getElementById('logs-modal-title');
-            const containerName = getContainerNameById(id);
-
-            title.textContent = `Logs for ${containerName}`;
-            content.textContent = 'Loading logs...';
-            modal.classList.remove('hidden');
-            modal.classList.add('flex');
-
-            try {
-                const result = await requestApiJson(`/api/containers/${id}/logs`);
-                if (result.error) {
-                    content.textContent = `Error: ${result.error}`;
-                } else {
-                    const nameFromServer = result.container || containerName;
-                    title.textContent = `Logs for ${nameFromServer}`;
-                    content.textContent = result.logs || 'No logs available.';
-                }
-            } catch (error) {
-                console.error('Error fetching logs:', error);
-                content.textContent = `Error loading logs: ${error.message}`;
-            }
-        }
-
-        function closeLogsModal() {
-            const modal = document.getElementById('logs-modal');
-            modal.classList.add('hidden');
-            modal.classList.remove('flex');
-        }
-
-        async function openContainerNetworkTest(id) {
-            const modal = document.getElementById('container-network-modal');
-            const title = document.getElementById('container-network-title');
-            const statusEl = document.getElementById('container-network-status');
-            const localEl = document.getElementById('container-network-local');
-            const publicEl = document.getElementById('container-network-public');
-            const outputEl = document.getElementById('container-network-output');
-            const methodEl = document.getElementById('container-network-method');
-
-            const containerName = getContainerNameById(id);
-            title.textContent = `Network Test: ${containerName}`;
-            statusEl.textContent = 'Running test...';
-            statusEl.classList.remove('text-green-400', 'text-red-400');
-            localEl.textContent = '-';
-            publicEl.textContent = '-';
-            methodEl.textContent = '-';
-            outputEl.textContent = 'Collecting diagnostics...';
-
-            modal.classList.remove('hidden');
-            modal.classList.add('flex');
-
-            try {
-                const result = await requestApiJson(`/api/containers/${id}/network-test`, { method: 'POST' });
-                if (result.error) {
-                    const message = result.error || 'Unable to run network test.';
-                    statusEl.textContent = 'Error';
-                    statusEl.classList.add('text-red-400');
-                    outputEl.textContent = message;
-                    showNotification(message, 'error');
-                    return;
-                }
-
-                statusEl.textContent = result.ping_success ? 'Success' : 'Failed';
-                statusEl.classList.toggle('text-green-400', !!result.ping_success);
-                statusEl.classList.toggle('text-red-400', !result.ping_success);
-                localEl.textContent = result.local_ip || 'Unavailable';
-                publicEl.textContent = result.public_ip || 'Unavailable';
-                methodEl.textContent = result.probe_method || 'unknown';
-                outputEl.textContent = result.ping_output || 'No output provided.';
-
-                showNotification(`Network test ${result.ping_success ? 'passed' : 'completed'}`, result.ping_success ? 'success' : 'info');
-            } catch (error) {
-                console.error('Container network test failed:', error);
-                statusEl.textContent = 'Error';
-                statusEl.classList.add('text-red-400');
-                outputEl.textContent = error.message;
-                showNotification('Network test failed', 'error');
-            }
-        }
-
-        async function runNetworkTest() {
-            const card = document.getElementById('network-test-card');
-            const statusEl = document.getElementById('network-test-status');
-            const outputEl = document.getElementById('network-test-output');
-            const localEl = document.getElementById('network-test-local');
-            const publicEl = document.getElementById('network-test-public');
-
-            card.classList.remove('hidden');
-            statusEl.textContent = 'Running test...';
-            statusEl.classList.remove('text-green-400', 'text-red-400');
-            outputEl.textContent = 'Executing ping...';
-            localEl.textContent = '-';
-            publicEl.textContent = '-';
-
-            try {
-                const result = await requestApiJson('/api/network-test', { method: 'POST' });
-
-                statusEl.textContent = result.ping_success ? 'Ping successful' : 'Ping failed';
-                statusEl.classList.toggle('text-green-400', !!result.ping_success);
-                statusEl.classList.toggle('text-red-400', !result.ping_success);
-                outputEl.textContent = result.ping_output || 'No ping output returned.';
-                localEl.textContent = result.local_ip || 'Unavailable';
-                publicEl.textContent = result.public_ip || 'Unavailable';
-
-                showNotification('Network test complete', result.ping_success ? 'success' : 'info');
-            } catch (error) {
-                console.error('Network test error:', error);
-                statusEl.textContent = 'Network test failed';
-                statusEl.classList.add('text-red-400');
-                outputEl.textContent = error.message;
-                showNotification('Network test failed', 'error');
-            }
-        }
-
-        // Logs modal controls
-        document.getElementById('logs-modal-close').addEventListener('click', closeLogsModal);
-        document.getElementById('logs-modal').addEventListener('click', function(event) {
-            if (event.target === this) {
-                closeLogsModal();
-            }
-        });
-
-        // Container network modal controls
-        document.getElementById('container-network-close').addEventListener('click', () => {
-            const modal = document.getElementById('container-network-modal');
-            modal.classList.add('hidden');
-            modal.classList.remove('flex');
-        });
-        document.getElementById('container-network-modal').addEventListener('click', function(event) {
-            if (event.target === this) {
-                this.classList.add('hidden');
-                this.classList.remove('flex');
-            }
-        });
-
-        // Network test controls
-        const networkTestButton = document.getElementById('network-test-button');
-        const hideNetworkTestButton = document.getElementById('hide-network-test');
-        networkTestButton.addEventListener('click', function() {
-            this.classList.add('animate-pulse');
-            runNetworkTest().finally(() => this.classList.remove('animate-pulse'));
-        });
-        hideNetworkTestButton.addEventListener('click', () => {
-            document.getElementById('network-test-card').classList.add('hidden');
-        });
-
-        // Set up filter buttons
-        document.getElementById('filter-all').addEventListener('click', function() {
-            setFilter('all', this);
-        });
-        
-        document.getElementById('filter-running').addEventListener('click', function() {
-            setFilter('running', this);
-        });
-        
-        document.getElementById('filter-stopped').addEventListener('click', function() {
-            setFilter('stopped', this);
-        });
-        
-        // Set filter and update UI
-        function setFilter(filter, button) {
-            if (currentFilter === filter) return;
-            
-            currentFilter = filter;
-            
-            // Update button styles
-            document.querySelectorAll('#filter-all, #filter-running, #filter-stopped').forEach(btn => {
-                btn.classList.remove('coraline-button');
-                btn.classList.add('bg-gray-700', 'hover:bg-gray-600');
-            });
-            
-            button.classList.remove('bg-gray-700', 'hover:bg-gray-600');
-            button.classList.add('coraline-button');
-            
-            // Re-render containers with the new filter
+        if (currentFilter !== 'all' && container.status !== currentFilter) {
             renderContainers();
-        }
-        
-        // Set up refresh button
-        document.getElementById('refresh-button').addEventListener('click', function() {
-            this.classList.add('animate-pulse');
-            fetchDockerContainers(true).then(() => {
-                this.classList.remove('animate-pulse');
+        } else {
+            updateActionButtons(row, container);
+
+            const otherActions = ['restart', 'check_update', 'update'];
+            otherActions.forEach((name) => {
+                const button = row.querySelector(`button[data-action="${name}"], button[data-menu-action="${name}"]`);
+                if (button) button.disabled = false;
             });
-        });
-        
-        // Expose handlers referenced by dynamic row button onclick attributes.
-        window.toggleDropdown = toggleDropdown;
-        window.closeDropdown = closeDropdown;
-        window.controlContainer = controlContainer;
-        window.viewLogs = viewLogs;
-        window.openContainerNetworkTest = openContainerNetworkTest;
-
-        async function initContainersPage() {
-            const authenticated = await ensureAuthenticated();
-            if (!authenticated) return;
-
-            await fetchDockerContainers();
-
-            // Periodic refresh with stats (after initial load, stats are included).
-            setInterval(() => fetchDockerContainers(false, true), 10000);
         }
 
-        initContainersPage();
+        lastFetchTime = Date.now();
+    } catch (error) {
+        console.error('Error updating container status:', error);
+        showNotification('Error updating container status', 'error');
+    }
+}
+
+async function viewLogs(id) {
+    const containerId = String(id);
+    const modal = document.getElementById('logs-modal');
+    const content = document.getElementById('logs-content');
+    const title = document.getElementById('logs-modal-title');
+    const containerName = getContainerNameById(containerId);
+
+    if (!modal || !content || !title) return;
+
+    title.textContent = `Logs for ${containerName}`;
+    content.textContent = 'Loading logs...';
+    modal.classList.remove('hidden');
+    modal.classList.add('flex');
+
+    try {
+        const result = await requestApiJson(`/api/containers/${encodeURIComponent(containerId)}/logs`);
+        if (result.error) {
+            content.textContent = `Error: ${result.error}`;
+        } else {
+            const nameFromServer = result.container || containerName;
+            title.textContent = `Logs for ${nameFromServer}`;
+            content.textContent = result.logs || 'No logs available.';
+        }
+    } catch (error) {
+        console.error('Error fetching logs:', error);
+        content.textContent = `Error loading logs: ${error.message}`;
+    }
+}
+
+function closeLogsModal() {
+    const modal = document.getElementById('logs-modal');
+    if (!modal) return;
+    modal.classList.add('hidden');
+    modal.classList.remove('flex');
+}
+
+async function openContainerNetworkTest(id) {
+    const containerId = String(id);
+    const modal = document.getElementById('container-network-modal');
+    const title = document.getElementById('container-network-title');
+    const statusEl = document.getElementById('container-network-status');
+    const localEl = document.getElementById('container-network-local');
+    const publicEl = document.getElementById('container-network-public');
+    const outputEl = document.getElementById('container-network-output');
+    const methodEl = document.getElementById('container-network-method');
+    const containerName = getContainerNameById(containerId);
+
+    if (!modal || !title || !statusEl || !localEl || !publicEl || !outputEl || !methodEl) {
+        return;
+    }
+
+    title.textContent = `Network Test: ${containerName}`;
+    statusEl.textContent = 'Running test...';
+    statusEl.classList.remove('text-green-400', 'text-red-400');
+    localEl.textContent = '-';
+    publicEl.textContent = '-';
+    methodEl.textContent = '-';
+    outputEl.textContent = 'Collecting diagnostics...';
+
+    modal.classList.remove('hidden');
+    modal.classList.add('flex');
+
+    try {
+        const result = await requestApiJson(`/api/containers/${encodeURIComponent(containerId)}/network-test`, { method: 'POST' });
+        if (result.error) {
+            const message = result.error || 'Unable to run network test.';
+            statusEl.textContent = 'Error';
+            statusEl.classList.add('text-red-400');
+            outputEl.textContent = message;
+            showNotification(message, 'error');
+            return;
+        }
+
+        statusEl.textContent = result.ping_success ? 'Success' : 'Failed';
+        statusEl.classList.toggle('text-green-400', !!result.ping_success);
+        statusEl.classList.toggle('text-red-400', !result.ping_success);
+        localEl.textContent = result.local_ip || 'Unavailable';
+        publicEl.textContent = result.public_ip || 'Unavailable';
+        methodEl.textContent = result.probe_method || 'unknown';
+        outputEl.textContent = result.ping_output || 'No output provided.';
+
+        showNotification(`Network test ${result.ping_success ? 'passed' : 'completed'}`, result.ping_success ? 'success' : 'info');
+    } catch (error) {
+        console.error('Container network test failed:', error);
+        statusEl.textContent = 'Error';
+        statusEl.classList.add('text-red-400');
+        outputEl.textContent = error.message;
+        showNotification('Network test failed', 'error');
+    }
+}
+
+async function runNetworkTest() {
+    const card = document.getElementById('network-test-card');
+    const statusEl = document.getElementById('network-test-status');
+    const outputEl = document.getElementById('network-test-output');
+    const localEl = document.getElementById('network-test-local');
+    const publicEl = document.getElementById('network-test-public');
+
+    if (!card || !statusEl || !outputEl || !localEl || !publicEl) return;
+
+    card.classList.remove('hidden');
+    statusEl.textContent = 'Running test...';
+    statusEl.classList.remove('text-green-400', 'text-red-400');
+    outputEl.textContent = 'Executing ping...';
+    localEl.textContent = '-';
+    publicEl.textContent = '-';
+
+    try {
+        const result = await requestApiJson('/api/network-test', { method: 'POST' });
+
+        statusEl.textContent = result.ping_success ? 'Ping successful' : 'Ping failed';
+        statusEl.classList.toggle('text-green-400', !!result.ping_success);
+        statusEl.classList.toggle('text-red-400', !result.ping_success);
+        outputEl.textContent = result.ping_output || 'No ping output returned.';
+        localEl.textContent = result.local_ip || 'Unavailable';
+        publicEl.textContent = result.public_ip || 'Unavailable';
+
+        showNotification('Network test complete', result.ping_success ? 'success' : 'info');
+    } catch (error) {
+        console.error('Network test error:', error);
+        statusEl.textContent = 'Network test failed';
+        statusEl.classList.add('text-red-400');
+        outputEl.textContent = error.message;
+        showNotification('Network test failed', 'error');
+    }
+}
+
+function setFilter(filter, button) {
+    if (currentFilter === filter) return;
+
+    currentFilter = filter;
+
+    document.querySelectorAll('#filter-all, #filter-running, #filter-stopped').forEach((btn) => {
+        btn.classList.remove('coraline-button');
+        btn.classList.add('bg-gray-700', 'hover:bg-gray-600');
+    });
+
+    button.classList.remove('bg-gray-700', 'hover:bg-gray-600');
+    button.classList.add('coraline-button');
+
+    renderContainers();
+}
+
+function bindModalHandlers() {
+    const logsClose = document.getElementById('logs-modal-close');
+    const logsModal = document.getElementById('logs-modal');
+    const containerNetworkClose = document.getElementById('container-network-close');
+    const containerNetworkModal = document.getElementById('container-network-modal');
+
+    logsClose?.addEventListener('click', closeLogsModal);
+    logsModal?.addEventListener('click', (event) => {
+        if (event.target === logsModal) {
+            closeLogsModal();
+        }
+    });
+
+    containerNetworkClose?.addEventListener('click', () => {
+        if (!containerNetworkModal) return;
+        containerNetworkModal.classList.add('hidden');
+        containerNetworkModal.classList.remove('flex');
+    });
+
+    containerNetworkModal?.addEventListener('click', (event) => {
+        if (event.target === containerNetworkModal) {
+            containerNetworkModal.classList.add('hidden');
+            containerNetworkModal.classList.remove('flex');
+        }
+    });
+}
+
+function bindStaticControls() {
+    const networkTestButton = document.getElementById('network-test-button');
+    const hideNetworkTestButton = document.getElementById('hide-network-test');
+    const refreshButton = document.getElementById('refresh-button');
+    const filterAll = document.getElementById('filter-all');
+    const filterRunning = document.getElementById('filter-running');
+    const filterStopped = document.getElementById('filter-stopped');
+
+    networkTestButton?.addEventListener('click', function onNetworkTestClick() {
+        this.classList.add('animate-pulse');
+        runNetworkTest().finally(() => this.classList.remove('animate-pulse'));
+    });
+
+    hideNetworkTestButton?.addEventListener('click', () => {
+        document.getElementById('network-test-card')?.classList.add('hidden');
+    });
+
+    filterAll?.addEventListener('click', function onFilterAll() {
+        setFilter('all', this);
+    });
+    filterRunning?.addEventListener('click', function onFilterRunning() {
+        setFilter('running', this);
+    });
+    filterStopped?.addEventListener('click', function onFilterStopped() {
+        setFilter('stopped', this);
+    });
+
+    refreshButton?.addEventListener('click', function onRefreshClick() {
+        this.classList.add('animate-pulse');
+        fetchDockerContainers(true).finally(() => this.classList.remove('animate-pulse'));
+    });
+}
+
+function bindContainerTableActions() {
+    const list = getContainerListEl();
+    if (!list) return;
+
+    list.addEventListener('click', async (event) => {
+        const toggleButton = event.target.closest('button[data-dropdown-toggle]');
+        if (toggleButton) {
+            event.preventDefault();
+            const { containerId } = toggleButton.dataset;
+            toggleDropdown(containerId);
+            return;
+        }
+
+        const menuActionButton = event.target.closest('button[data-menu-action]');
+        if (menuActionButton) {
+            event.preventDefault();
+            const { containerId, menuAction } = menuActionButton.dataset;
+
+            if (menuAction === 'logs') {
+                await viewLogs(containerId);
+            } else if (menuAction === 'network-test') {
+                await openContainerNetworkTest(containerId);
+            } else if (menuAction) {
+                await controlContainer(containerId, menuAction);
+            }
+
+            closeDropdown(containerId);
+            return;
+        }
+
+        const actionButton = event.target.closest('button[data-action]');
+        if (actionButton) {
+            event.preventDefault();
+            const { containerId, action } = actionButton.dataset;
+            if (containerId && action) {
+                await controlContainer(containerId, action);
+            }
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        if (!event.target.closest('[data-dropdown-container]')) {
+            closeAllDropdowns();
+        }
+    });
+}
+
+async function initContainersPage() {
+    const authenticated = await ensureAuthenticated();
+    if (!authenticated) return;
+
+    bindModalHandlers();
+    bindStaticControls();
+    bindContainerTableActions();
+
+    await fetchDockerContainers();
+
+    window.setInterval(() => fetchDockerContainers(false, true), 10000);
+}
+
+initContainersPage();

--- a/static/js/pages/containers.js
+++ b/static/js/pages/containers.js
@@ -1,43 +1,14 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
-import { requestJson } from '/js/lib/http.js';
+import { requestApiJson } from '/js/lib/http.js';
+import { formatBytes as formatBaseBytes } from '/js/lib/format.js';
+import { showNotification as showBaseNotification } from '/js/lib/notify.js';
 
 window.logout = logoutToLogin;
 
-async function requestApiJson(url, options = {}) {
-    const { response, payload } = await requestJson(url, options);
-
-    if (!response.ok) {
-        throw new Error(payload?.error || `Request failed (${response.status})`);
-    }
-
-    return payload || {};
-}
-
 function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    if (!area) {
-        return;
-    }
-
-    const notification = document.createElement('div');
-    notification.className = 'bg-opacity-90 p-3 mb-2 rounded shadow-lg transform transition-all duration-500 opacity-0 text-white';
-
-    if (type === 'success') {
-        notification.classList.add('bg-green-600');
-    } else if (type === 'error') {
-        notification.classList.add('bg-red-600');
-    } else {
-        notification.classList.add('bg-blue-600');
-    }
-
-    notification.textContent = message;
-    area.appendChild(notification);
-
-    window.setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    window.setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        window.setTimeout(() => notification.remove(), 300);
-    }, 3000);
+    showBaseNotification(message, type, {
+        baseClass: 'bg-opacity-90 p-3 mb-2 rounded shadow-lg transform transition-all duration-500 opacity-0 text-white',
+    });
 }
 
 function formatDateTime(date) {
@@ -50,12 +21,7 @@ function formatDateTime(date) {
 function formatBytes(bytes) {
     const value = Number(bytes);
     if (!Number.isFinite(value) || value < 0) return '—';
-    if (value === 0) return '0 B';
-
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.min(Math.floor(Math.log(value) / Math.log(k)), sizes.length - 1);
-    return `${parseFloat((value / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+    return formatBaseBytes(value, 1);
 }
 
 function getStatColorClass(percent) {

--- a/static/js/pages/disks.js
+++ b/static/js/pages/disks.js
@@ -1,7 +1,10 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
 import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { escapeHtml, encodeDataAttr, formatBytes } from '/js/lib/format.js';
+import { showNotification } from '/js/lib/notify.js';
+import { setNodeContent } from '/js/lib/dom.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -13,68 +16,11 @@ let currentMount = {};
 let smartData = [];
 let currentSmartDevice = null;
 
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
-
-function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    const notification = document.createElement('div');
-    notification.className = 'p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0';
-    if (type === 'success') notification.classList.add('bg-green-600');
-    else if (type === 'error') notification.classList.add('bg-red-600');
-    else notification.classList.add('bg-blue-600');
-    notification.textContent = message;
-    area.appendChild(notification);
-    setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        setTimeout(() => notification.remove(), 300);
-    }, 3000);
-}
-
-function formatBytes(bytes) {
-    if (!bytes || bytes === 0) return '0 B';
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
-}
-
-function escapeHtml(str) {
-    if (!str) return '';
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function encodeDataAttr(value) {
-    return escapeHtml(String(value ?? ''));
-}
-
 function parseDataBool(value, defaultValue = false) {
     if (value === undefined || value === null || value === '') {
         return defaultValue;
     }
     return value === 'true';
-}
-
-function setNodeContent(containerId, node) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-        return;
-    }
-    clearElement(container);
-    container.appendChild(node);
 }
 
 function renderHelperUnavailable() {
@@ -119,7 +65,7 @@ async function loadDisks() {
     }));
 
     try {
-        const response = await apiFetch('/api/disks');
+        const response = await requestApiResponse('/api/disks');
         const data = await response.json().catch(() => ({}));
 
         if (!response.ok) {
@@ -277,7 +223,7 @@ function bindDiskActions(diskList) {
 
 async function loadSuggestions() {
     try {
-        const response = await apiFetch('/api/disks/suggested-mounts');
+        const response = await requestApiResponse('/api/disks/suggested-mounts');
         const data = await response.json().catch(() => ({}));
         if (!response.ok) {
             throw new Error(data?.error || `Failed to load suggestions (${response.status})`);
@@ -368,7 +314,7 @@ async function submitMount() {
     }
 
     try {
-        const response = await apiFetch('/api/disks/mount', {
+        const response = await requestApiResponse('/api/disks/mount', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -397,7 +343,7 @@ async function unmountDisk(mountpoint) {
     }
 
     try {
-        const response = await apiFetch('/api/disks/unmount', {
+        const response = await requestApiResponse('/api/disks/unmount', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -426,7 +372,7 @@ async function loadSmartData() {
     smartList.innerHTML = '<div class="text-gray-400 text-sm">Loading SMART data...</div>';
 
     try {
-        const response = await apiFetch('/api/disks/smart');
+        const response = await requestApiResponse('/api/disks/smart');
         const data = await response.json().catch(() => ({}));
 
         if (data.error) {
@@ -563,7 +509,7 @@ async function openSmartModal(deviceName) {
     }
 
     try {
-        const response = await apiFetch(`/api/disks/${encodeURIComponent(deviceName)}/smart`);
+        const response = await requestApiResponse(`/api/disks/${encodeURIComponent(deviceName)}/smart`);
         const data = await response.json().catch(() => ({}));
 
         if (data.error) {
@@ -719,7 +665,7 @@ async function runSmartTest(testType) {
     }
 
     try {
-        const response = await apiFetch(`/api/disks/${encodeURIComponent(currentSmartDevice)}/smart-test`, {
+        const response = await requestApiResponse(`/api/disks/${encodeURIComponent(currentSmartDevice)}/smart-test`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ test_type: testType }),
@@ -736,14 +682,67 @@ async function runSmartTest(testType) {
     }
 }
 
-Object.assign(window, {
-    loadDisks,
-    loadSmartData,
-    closeMountModal,
-    submitMount,
-    closeSmartModal,
-    runSmartTest,
-});
+function bindDiskPageActions() {
+    const refreshButton = document.getElementById('disks-refresh-btn');
+    if (refreshButton) {
+        refreshButton.addEventListener('click', loadDisks);
+    }
+
+    const refreshSmartButton = document.getElementById('disks-smart-refresh-btn');
+    if (refreshSmartButton) {
+        refreshSmartButton.addEventListener('click', loadSmartData);
+    }
+
+    const closeMountTop = document.getElementById('disks-close-mount-top');
+    if (closeMountTop) {
+        closeMountTop.addEventListener('click', closeMountModal);
+    }
+
+    const closeMountBottom = document.getElementById('disks-close-mount-bottom');
+    if (closeMountBottom) {
+        closeMountBottom.addEventListener('click', closeMountModal);
+    }
+
+    const submitMountButton = document.getElementById('disks-submit-mount');
+    if (submitMountButton) {
+        submitMountButton.addEventListener('click', submitMount);
+    }
+
+    const smartModal = document.getElementById('smart-modal');
+    if (smartModal) {
+        smartModal.addEventListener('click', (event) => {
+            if (event.target === smartModal) {
+                closeSmartModal();
+            }
+        });
+    }
+
+    const smartModalPanel = document.querySelector('#smart-modal [data-modal-panel]');
+    if (smartModalPanel) {
+        smartModalPanel.addEventListener('click', (event) => {
+            event.stopPropagation();
+        });
+    }
+
+    const closeSmartTop = document.getElementById('disks-close-smart-top');
+    if (closeSmartTop) {
+        closeSmartTop.addEventListener('click', closeSmartModal);
+    }
+
+    const closeSmartBottom = document.getElementById('disks-close-smart-bottom');
+    if (closeSmartBottom) {
+        closeSmartBottom.addEventListener('click', closeSmartModal);
+    }
+
+    document.querySelectorAll('[data-smart-test]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const testType = button.dataset.smartTest;
+            if (testType) {
+                runSmartTest(testType);
+            }
+        });
+    });
+}
 
 (async function initDisksPage() {
     const authenticated = await ensureAuthenticated();
@@ -752,5 +751,6 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    bindDiskPageActions();
     await loadDisks();
 })();

--- a/static/js/pages/index.js
+++ b/static/js/pages/index.js
@@ -1,5 +1,11 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
 import { requestJson } from '/js/lib/http.js';
+
+ensureDashboardShell({
+    navClass: 'bg-slate-900/90 shadow-md',
+    notificationClass: 'fixed top-4 right-4 z-50 space-y-2',
+});
 
 const serviceGrid = document.getElementById('service-grid');
 const serviceCount = document.getElementById('service-count');

--- a/static/js/pages/mounts.js
+++ b/static/js/pages/mounts.js
@@ -1,6 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearClientSession } from '/js/lib/session.js';
+import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -21,6 +22,15 @@ let mountPlugins = [];
 let currentMountPlugin = null;
 let currentMountId = null;
 let mediaPaths = {};
+
+function setNodeContent(containerId, node) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    clearElement(container);
+    container.appendChild(node);
+}
 
 function showNotification(message, type = 'info') {
     const area = document.getElementById('notification-area');
@@ -192,6 +202,12 @@ async function applyStartupService() {
 
 // ========== Mount Plugins ==========
 async function loadMountPlugins() {
+    setNodeContent('mount-plugins', createLoadingState({
+        message: 'Loading mount plugins...',
+        containerClass: 'text-center py-10',
+        messageClass: 'text-gray-400',
+    }));
+
     try {
         const res = await apiFetch('/api/storage/plugins');
         const data = await res.json();
@@ -203,8 +219,11 @@ async function loadMountPlugins() {
 
         await renderMountPluginSections();
     } catch (e) {
-        document.getElementById('mount-plugins').innerHTML =
-            `<p class="text-red-400">Failed to load plugins: ${e.message}</p>`;
+        setNodeContent('mount-plugins', createErrorState({
+            title: `Failed to load plugins: ${e.message}`,
+            containerClass: 'text-center py-10',
+            titleClass: 'text-red-400',
+        }));
     }
 }
 
@@ -212,12 +231,13 @@ async function renderMountPluginSections() {
     const container = document.getElementById('mount-plugins');
 
     if (!mountPlugins.length) {
-        container.innerHTML = `
-            <div class="text-center py-10">
-                <p class="text-gray-500 mb-2">No mount plugins enabled.</p>
-                <a href="/plugins.html" class="text-purple-400 hover:underline">Enable plugins &rarr;</a>
-            </div>
-        `;
+        setNodeContent('mount-plugins', createEmptyState({
+            title: 'No mount plugins enabled.',
+            action: { href: '/plugins.html', label: 'Enable plugins →' },
+            containerClass: 'text-center py-10',
+            titleClass: 'text-gray-500 mb-2',
+            actionClass: 'text-purple-400 hover:underline',
+        }));
         return;
     }
 

--- a/static/js/pages/mounts.js
+++ b/static/js/pages/mounts.js
@@ -1,66 +1,20 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
-import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { escapeHtml, encodeDataAttr } from '/js/lib/format.js';
+import { showNotification } from '/js/lib/notify.js';
+import { setNodeContent } from '/js/lib/dom.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
     includeFooter: true,
 });
 
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
-
 let mountPlugins = [];
 let currentMountPlugin = null;
 let currentMountId = null;
 let mediaPaths = {};
-
-function setNodeContent(containerId, node) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-        return;
-    }
-    clearElement(container);
-    container.appendChild(node);
-}
-
-function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    const notification = document.createElement('div');
-    notification.className = 'p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0';
-    if (type === 'success') notification.classList.add('bg-green-600');
-    else if (type === 'error') notification.classList.add('bg-red-600');
-    else notification.classList.add('bg-blue-600');
-    notification.textContent = message;
-    area.appendChild(notification);
-    setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        setTimeout(() => notification.remove(), 300);
-    }, 3000);
-}
-
-function escapeHtml(str) {
-    if (!str) return '';
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function encodeDataAttr(value) {
-    return escapeHtml(String(value ?? ''));
-}
 
 async function loadPage() {
     await Promise.all([
@@ -72,7 +26,7 @@ async function loadPage() {
 // ========== Media Paths ==========
 async function loadMediaPaths() {
     try {
-        const response = await apiFetch('/api/disks/media-paths');
+        const response = await requestApiResponse('/api/disks/media-paths');
         const data = await response.json();
         mediaPaths = data.paths || {};
 
@@ -94,7 +48,7 @@ async function saveMediaPaths() {
     };
 
     try {
-        const response = await apiFetch('/api/disks/media-paths', {
+        const response = await requestApiResponse('/api/disks/media-paths', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(paths)
@@ -111,7 +65,7 @@ async function saveMediaPaths() {
 // ========== Startup Service Diff ==========
 async function previewStartupService() {
     try {
-        const res = await apiFetch('/api/disks/startup-service/preview');
+        const res = await requestApiResponse('/api/disks/startup-service/preview');
         if (!res.ok) {
             const errData = await res.json().catch(() => ({}));
             const errMsg = errData.error || `Preview failed (${res.status})`;
@@ -190,7 +144,7 @@ function closeDiffModal() {
 
 async function applyStartupService() {
     try {
-        const res = await apiFetch('/api/disks/startup-service', { method: 'POST' });
+        const res = await requestApiResponse('/api/disks/startup-service', { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || 'Failed to update service');
         showNotification('Startup service updated', 'success');
@@ -209,7 +163,7 @@ async function loadMountPlugins() {
     }));
 
     try {
-        const res = await apiFetch('/api/storage/plugins');
+        const res = await requestApiResponse('/api/storage/plugins');
         const data = await res.json();
 
         // Filter to only mount-category plugins that are enabled
@@ -246,7 +200,7 @@ async function renderMountPluginSections() {
         // Fetch mounts for this plugin
         let mounts = [];
         try {
-            const res = await apiFetch(`/api/storage/mounts/${plugin.id}`);
+            const res = await requestApiResponse(`/api/storage/mounts/${plugin.id}`);
             const data = await res.json();
             mounts = data.mounts || [];
         } catch (e) {
@@ -261,16 +215,16 @@ async function renderMountPluginSections() {
                         <p class="text-sm text-gray-400">${escapeHtml(plugin.description)}</p>
                     </div>
                     <div class="flex gap-2">
-                        <button onclick="detectMounts(this.dataset.pluginId)"
+                        <button type="button"
+                                class="js-detect-mounts py-2 px-4 rounded text-sm border border-purple-700 text-purple-300 hover:bg-purple-900"
                                 data-plugin-id="${encodeDataAttr(plugin.id)}"
-                                class="py-2 px-4 rounded text-sm border border-purple-700 text-purple-300 hover:bg-purple-900"
                                 ${!plugin.installed ? 'disabled' : ''}
                                 title="Detect existing mounts on this system">
                             Detect
                         </button>
-                        <button onclick="openAddMountModal(this.dataset.pluginId)"
+                        <button type="button"
+                                class="js-open-add-mount coraline-button py-2 px-4 rounded text-sm"
                                 data-plugin-id="${encodeDataAttr(plugin.id)}"
-                                class="coraline-button py-2 px-4 rounded text-sm"
                                 ${!plugin.installed ? 'disabled title="Install dependencies first"' : ''}>
                             + Add Mount
                         </button>
@@ -295,6 +249,47 @@ async function renderMountPluginSections() {
     }
 
     container.innerHTML = html;
+    bindMountPluginActions(container);
+}
+
+function bindMountPluginActions(container) {
+    if (!container) return;
+
+    container.querySelectorAll('.js-detect-mounts').forEach((button) => {
+        button.addEventListener('click', () => {
+            detectMounts(button.dataset.pluginId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-open-add-mount').forEach((button) => {
+        button.addEventListener('click', () => {
+            openAddMountModal(button.dataset.pluginId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-mount-remote').forEach((button) => {
+        button.addEventListener('click', () => {
+            mountRemote(button.dataset.pluginId || '', button.dataset.mountId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-unmount-remote').forEach((button) => {
+        button.addEventListener('click', () => {
+            unmountRemote(button.dataset.pluginId || '', button.dataset.mountId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-edit-mount').forEach((button) => {
+        button.addEventListener('click', () => {
+            editMount(button.dataset.pluginId || '', button.dataset.mountId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-remove-mount').forEach((button) => {
+        button.addEventListener('click', () => {
+            removeMount(button.dataset.pluginId || '', button.dataset.mountId || '');
+        });
+    });
 }
 
 function renderMountCard(pluginId, mount) {
@@ -323,11 +318,11 @@ function renderMountCard(pluginId, mount) {
             <div class="flex items-center gap-3">
                 <span class="status-pill ${statusClass}">${statusText}</span>
                 ${mount.mounted ?
-                    `<button onclick="unmountRemote(this.dataset.pluginId, this.dataset.mountId)" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}" class="text-sm text-red-400 hover:text-red-300">Unmount</button>` :
-                    `<button onclick="mountRemote(this.dataset.pluginId, this.dataset.mountId)" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}" class="text-sm text-green-400 hover:text-green-300">Mount</button>`
+                    `<button type="button" class="js-unmount-remote text-sm text-red-400 hover:text-red-300" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}">Unmount</button>` :
+                    `<button type="button" class="js-mount-remote text-sm text-green-400 hover:text-green-300" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}">Mount</button>`
                 }
-                <button onclick="editMount(this.dataset.pluginId, this.dataset.mountId)" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}" class="text-sm text-gray-400 hover:text-white">Edit</button>
-                <button onclick="removeMount(this.dataset.pluginId, this.dataset.mountId)" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}" class="text-sm text-gray-400 hover:text-red-400">Remove</button>
+                <button type="button" class="js-edit-mount text-sm text-gray-400 hover:text-white" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}">Edit</button>
+                <button type="button" class="js-remove-mount text-sm text-gray-400 hover:text-red-400" data-plugin-id="${encodeDataAttr(pluginId)}" data-mount-id="${encodeDataAttr(mount.id)}">Remove</button>
             </div>
         </div>
     `;
@@ -336,7 +331,7 @@ function renderMountCard(pluginId, mount) {
 // ========== Mount Operations ==========
 async function mountRemote(pluginId, mountId) {
     try {
-        const res = await apiFetch(`/api/storage/mounts/${pluginId}/${mountId}/mount`, { method: 'POST' });
+        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/${mountId}/mount`, { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
         showNotification('Mounted successfully', 'success');
@@ -348,7 +343,7 @@ async function mountRemote(pluginId, mountId) {
 
 async function unmountRemote(pluginId, mountId) {
     try {
-        const res = await apiFetch(`/api/storage/mounts/${pluginId}/${mountId}/unmount`, { method: 'POST' });
+        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/${mountId}/unmount`, { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
         showNotification('Unmounted successfully', 'success');
@@ -361,7 +356,7 @@ async function unmountRemote(pluginId, mountId) {
 async function removeMount(pluginId, mountId) {
     if (!confirm('Remove this mount configuration?')) return;
     try {
-        const res = await apiFetch(`/api/storage/mounts/${pluginId}/${mountId}`, { method: 'DELETE' });
+        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/${mountId}`, { method: 'DELETE' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
         showNotification('Mount removed', 'success');
@@ -374,7 +369,7 @@ async function removeMount(pluginId, mountId) {
 async function detectMounts(pluginId) {
     try {
         showNotification('Detecting existing mounts...', 'info');
-        const res = await apiFetch(`/api/storage/mounts/${pluginId}/detect`, { method: 'POST' });
+        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/detect`, { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
 
@@ -398,7 +393,7 @@ async function openAddMountModal(pluginId) {
 
     // Load schema for this plugin
     try {
-        const res = await apiFetch(`/api/storage/plugins/${pluginId}`);
+        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}`);
         const data = await res.json();
         renderMountForm(data.schema, {});
     } catch (e) {
@@ -418,8 +413,8 @@ async function editMount(pluginId, mountId) {
     // Load plugin schema and mount data
     try {
         const [schemaRes, mountsRes] = await Promise.all([
-            apiFetch(`/api/storage/plugins/${pluginId}`),
-            apiFetch(`/api/storage/mounts/${pluginId}`)
+            requestApiResponse(`/api/storage/plugins/${pluginId}`),
+            requestApiResponse(`/api/storage/mounts/${pluginId}`)
         ]);
         const schemaData = await schemaRes.json();
         const mountsData = await mountsRes.json();
@@ -513,13 +508,13 @@ async function submitMountForm() {
     try {
         let res;
         if (currentMountId) {
-            res = await apiFetch(`/api/storage/mounts/${currentMountPlugin}/${currentMountId}`, {
+            res = await requestApiResponse(`/api/storage/mounts/${currentMountPlugin}/${currentMountId}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)
             });
         } else {
-            res = await apiFetch(`/api/storage/mounts/${currentMountPlugin}`, {
+            res = await requestApiResponse(`/api/storage/mounts/${currentMountPlugin}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)
@@ -537,20 +532,40 @@ async function submitMountForm() {
     }
 }
 
-Object.assign(window, {
-    saveMediaPaths,
-    previewStartupService,
-    closeDiffModal,
-    applyStartupService,
-    detectMounts,
-    openAddMountModal,
-    closeMountModal,
-    submitMountForm,
-    mountRemote,
-    unmountRemote,
-    editMount,
-    removeMount,
-});
+function bindMountPageActions() {
+    document.getElementById('save-media-paths')?.addEventListener('click', saveMediaPaths);
+    document.getElementById('preview-startup-service')?.addEventListener('click', previewStartupService);
+
+    document.addEventListener('click', (event) => {
+        const trigger = event.target.closest('[data-action]');
+        if (trigger) {
+            const { action } = trigger.dataset;
+            switch (action) {
+            case 'close-mount-modal':
+                closeMountModal();
+                break;
+            case 'submit-mount-form':
+                submitMountForm();
+                break;
+            case 'close-diff-modal':
+                closeDiffModal();
+                break;
+            case 'apply-startup-service':
+                applyStartupService();
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (event.target instanceof HTMLElement && event.target.matches('[data-overlay-close]')) {
+            const modalId = event.target.dataset.overlayClose;
+            if (modalId) {
+                document.getElementById(modalId)?.classList.add('hidden');
+            }
+        }
+    });
+}
 
 (async function initMountsPage() {
     const authenticated = await ensureAuthenticated();
@@ -559,5 +574,6 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    bindMountPageActions();
     await loadPage();
 })();

--- a/static/js/pages/mounts.js
+++ b/static/js/pages/mounts.js
@@ -16,6 +16,21 @@ let currentMountPlugin = null;
 let currentMountId = null;
 let mediaPaths = {};
 
+function normalizeMountPlugins(rawPlugins) {
+    if (!Array.isArray(rawPlugins)) {
+        return [];
+    }
+
+    return rawPlugins
+        .filter((plugin) => plugin && typeof plugin === 'object')
+        .map((plugin) => ({
+            ...plugin,
+            id: typeof plugin.id === 'string' ? plugin.id.trim() : '',
+            category: typeof plugin.category === 'string' ? plugin.category : '',
+        }))
+        .filter((plugin) => plugin.id && plugin.category === 'mount' && plugin.enabled);
+}
+
 async function loadPage() {
     await Promise.all([
         loadMediaPaths(),
@@ -27,7 +42,10 @@ async function loadPage() {
 async function loadMediaPaths() {
     try {
         const response = await requestApiResponse('/api/disks/media-paths');
-        const data = await response.json();
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(data.error || `Failed to load media paths (${response.status})`);
+        }
         mediaPaths = data.paths || {};
 
         document.getElementById('path-downloads').value = mediaPaths.downloads || '';
@@ -164,12 +182,12 @@ async function loadMountPlugins() {
 
     try {
         const res = await requestApiResponse('/api/storage/plugins');
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || `Failed to load plugins (${res.status})`);
+        }
 
-        // Filter to only mount-category plugins that are enabled
-        mountPlugins = (data.plugins || []).filter(p =>
-            p.category === 'mount' && p.enabled
-        );
+        mountPlugins = normalizeMountPlugins(data.plugins);
 
         await renderMountPluginSections();
     } catch (e) {
@@ -200,8 +218,11 @@ async function renderMountPluginSections() {
         // Fetch mounts for this plugin
         let mounts = [];
         try {
-            const res = await requestApiResponse(`/api/storage/mounts/${plugin.id}`);
-            const data = await res.json();
+            const res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(plugin.id)}`);
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                throw new Error(data.error || `Failed to load mounts (${res.status})`);
+            }
             mounts = data.mounts || [];
         } catch (e) {
             console.error(`Failed to load mounts for ${plugin.id}:`, e);
@@ -331,7 +352,7 @@ function renderMountCard(pluginId, mount) {
 // ========== Mount Operations ==========
 async function mountRemote(pluginId, mountId) {
     try {
-        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/${mountId}/mount`, { method: 'POST' });
+        const res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(pluginId)}/${encodeURIComponent(mountId)}/mount`, { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
         showNotification('Mounted successfully', 'success');
@@ -343,7 +364,7 @@ async function mountRemote(pluginId, mountId) {
 
 async function unmountRemote(pluginId, mountId) {
     try {
-        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/${mountId}/unmount`, { method: 'POST' });
+        const res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(pluginId)}/${encodeURIComponent(mountId)}/unmount`, { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
         showNotification('Unmounted successfully', 'success');
@@ -356,7 +377,7 @@ async function unmountRemote(pluginId, mountId) {
 async function removeMount(pluginId, mountId) {
     if (!confirm('Remove this mount configuration?')) return;
     try {
-        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/${mountId}`, { method: 'DELETE' });
+        const res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(pluginId)}/${encodeURIComponent(mountId)}`, { method: 'DELETE' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
         showNotification('Mount removed', 'success');
@@ -369,7 +390,7 @@ async function removeMount(pluginId, mountId) {
 async function detectMounts(pluginId) {
     try {
         showNotification('Detecting existing mounts...', 'info');
-        const res = await requestApiResponse(`/api/storage/mounts/${pluginId}/detect`, { method: 'POST' });
+        const res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(pluginId)}/detect`, { method: 'POST' });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error);
 
@@ -393,8 +414,11 @@ async function openAddMountModal(pluginId) {
 
     // Load schema for this plugin
     try {
-        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}`);
-        const data = await res.json();
+        const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}`);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || `Failed to load plugin schema (${res.status})`);
+        }
         renderMountForm(data.schema, {});
     } catch (e) {
         showNotification('Failed to load form: ' + e.message, 'error');
@@ -413,11 +437,17 @@ async function editMount(pluginId, mountId) {
     // Load plugin schema and mount data
     try {
         const [schemaRes, mountsRes] = await Promise.all([
-            requestApiResponse(`/api/storage/plugins/${pluginId}`),
-            requestApiResponse(`/api/storage/mounts/${pluginId}`)
+            requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}`),
+            requestApiResponse(`/api/storage/mounts/${encodeURIComponent(pluginId)}`)
         ]);
-        const schemaData = await schemaRes.json();
-        const mountsData = await mountsRes.json();
+        const schemaData = await schemaRes.json().catch(() => ({}));
+        const mountsData = await mountsRes.json().catch(() => ({}));
+        if (!schemaRes.ok) {
+            throw new Error(schemaData.error || `Failed to load plugin schema (${schemaRes.status})`);
+        }
+        if (!mountsRes.ok) {
+            throw new Error(mountsData.error || `Failed to load mounts (${mountsRes.status})`);
+        }
         const mount = (mountsData.mounts || []).find(m => m.id === mountId);
         renderMountForm(schemaData.schema, mount || {});
     } catch (e) {
@@ -430,8 +460,9 @@ async function editMount(pluginId, mountId) {
 
 function renderMountForm(schema, values) {
     const form = document.getElementById('mount-modal-form');
-    const properties = schema.properties || {};
-    const required = schema.required || [];
+    const schemaObj = schema && typeof schema === 'object' ? schema : {};
+    const properties = schemaObj.properties && typeof schemaObj.properties === 'object' ? schemaObj.properties : {};
+    const required = Array.isArray(schemaObj.required) ? schemaObj.required : [];
 
     let html = '';
     for (const [key, prop] of Object.entries(properties)) {
@@ -487,6 +518,11 @@ function closeMountModal() {
 }
 
 async function submitMountForm() {
+    if (!currentMountPlugin) {
+        showNotification('No mount plugin selected', 'error');
+        return;
+    }
+
     const form = document.getElementById('mount-modal-form');
     const formData = {};
 
@@ -508,13 +544,13 @@ async function submitMountForm() {
     try {
         let res;
         if (currentMountId) {
-            res = await requestApiResponse(`/api/storage/mounts/${currentMountPlugin}/${currentMountId}`, {
+            res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(currentMountPlugin)}/${encodeURIComponent(currentMountId)}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)
             });
         } else {
-            res = await requestApiResponse(`/api/storage/mounts/${currentMountPlugin}`, {
+            res = await requestApiResponse(`/api/storage/mounts/${encodeURIComponent(currentMountPlugin)}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)

--- a/static/js/pages/network.js
+++ b/static/js/pages/network.js
@@ -1,6 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearClientSession } from '/js/lib/session.js';
+import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -27,13 +28,26 @@ function escapeHtml(text) {
         .replace(/'/g, '&#39;');
 }
 
+function setNodeContent(containerId, node) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    clearElement(container);
+    container.appendChild(node);
+}
+
 function showLoadError(message) {
     const loadingState = document.getElementById('loading-state');
     if (!loadingState) {
         return;
     }
 
-    loadingState.innerHTML = `<p class="text-red-400">Failed to load network info: ${escapeHtml(message)}</p>`;
+    setNodeContent('loading-state', createErrorState({
+        title: `Failed to load network info: ${message}`,
+        containerClass: 'text-center py-10',
+        titleClass: 'text-red-400',
+    }));
 }
 
 async function loadNetworkInfo() {
@@ -88,7 +102,12 @@ function renderNetworkInfo(data) {
                 </div>
             `).join('');
         } else {
-            dnsContainer.innerHTML = '<p class="text-gray-500">No DNS servers configured</p>';
+            clearElement(dnsContainer);
+            dnsContainer.appendChild(createEmptyState({
+                title: 'No DNS servers configured',
+                containerClass: 'text-center py-2',
+                titleClass: 'text-gray-500',
+            }));
         }
     }
 
@@ -98,7 +117,12 @@ function renderNetworkInfo(data) {
         if (interfaces.length > 0) {
             interfacesContainer.innerHTML = interfaces.map((iface) => renderInterface(iface)).join('');
         } else {
-            interfacesContainer.innerHTML = '<p class="text-gray-500">No network interfaces found</p>';
+            clearElement(interfacesContainer);
+            interfacesContainer.appendChild(createEmptyState({
+                title: 'No network interfaces found',
+                containerClass: 'text-center py-2',
+                titleClass: 'text-gray-500',
+            }));
         }
     }
 }
@@ -158,13 +182,11 @@ function refreshNetworkInfo() {
 
     if (loadingState) {
         loadingState.classList.remove('hidden');
-        loadingState.innerHTML = `
-            <svg class="animate-spin h-8 w-8 mx-auto mb-4 text-purple-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
-            Loading network information...
-        `;
+        setNodeContent('loading-state', createLoadingState({
+            message: 'Loading network information...',
+            containerClass: 'text-center py-10',
+            messageClass: 'text-gray-400',
+        }));
     }
 
     if (networkContent) {

--- a/static/js/pages/network.js
+++ b/static/js/pages/network.js
@@ -1,41 +1,14 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
 import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { escapeHtml } from '/js/lib/format.js';
+import { setNodeContent } from '/js/lib/dom.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
     includeFooter: true,
 });
-
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
-
-function escapeHtml(text) {
-    if (!text) return '';
-    return String(text)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function setNodeContent(containerId, node) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-        return;
-    }
-    clearElement(container);
-    container.appendChild(node);
-}
 
 function showLoadError(message) {
     const loadingState = document.getElementById('loading-state');
@@ -52,7 +25,7 @@ function showLoadError(message) {
 
 async function loadNetworkInfo() {
     try {
-        const response = await apiFetch('/api/network/info');
+        const response = await requestApiResponse('/api/network/info');
         const data = await response.json().catch(() => ({}));
 
         if (!response.ok) {
@@ -196,10 +169,6 @@ function refreshNetworkInfo() {
     loadNetworkInfo();
 }
 
-Object.assign(window, {
-    refreshNetworkInfo,
-});
-
 (async function initNetworkPage() {
     const authenticated = await ensureAuthenticated();
     if (!authenticated) {
@@ -207,5 +176,6 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    document.getElementById('refresh-network-info')?.addEventListener('click', refreshNetworkInfo);
     await loadNetworkInfo();
 })();

--- a/static/js/pages/plugins.js
+++ b/static/js/pages/plugins.js
@@ -36,6 +36,21 @@ const CATEGORY_SECTIONS = [
         iconPath: 'M3 7h8m-8 5h18m-10 5h10',
     },
 ];
+const KNOWN_CATEGORY_KEYS = new Set(CATEGORY_SECTIONS.map((section) => section.key));
+
+function normalizePluginList(rawPlugins) {
+    if (!Array.isArray(rawPlugins)) {
+        return [];
+    }
+
+    return rawPlugins
+        .filter((plugin) => plugin && typeof plugin === 'object')
+        .map((plugin) => ({
+            ...plugin,
+            id: typeof plugin.id === 'string' ? plugin.id.trim() : '',
+            category: typeof plugin.category === 'string' ? plugin.category.trim() : '',
+        }));
+}
 
 function statusClass(status) {
     if (status === 'healthy') return 'status-healthy';
@@ -61,11 +76,11 @@ async function loadPlugins() {
 
     try {
         const response = await requestApiResponse('/api/storage/plugins');
-        const payload = await response.json();
+        const payload = await response.json().catch(() => ({}));
         if (!response.ok) {
             throw new Error(payload?.error || `Failed to load plugins (${response.status})`);
         }
-        renderPlugins(payload.plugins || []);
+        renderPlugins(payload.plugins);
     } catch (error) {
         setContainerNode(createErrorState({
             title: `Failed to load plugins: ${error.message}`,
@@ -81,7 +96,8 @@ function renderPlugins(plugins) {
         return;
     }
 
-    if (!plugins.length) {
+    const normalizedPlugins = normalizePluginList(plugins);
+    if (!normalizedPlugins.length) {
         setContainerNode(createEmptyState({
             title: 'No plugins available',
             containerClass: 'text-center py-10',
@@ -92,7 +108,7 @@ function renderPlugins(plugins) {
 
     let html = '';
     for (const section of CATEGORY_SECTIONS) {
-        const sectionPlugins = plugins.filter((plugin) => plugin.category === section.key);
+        const sectionPlugins = normalizedPlugins.filter((plugin) => plugin.category === section.key);
         if (!sectionPlugins.length) {
             continue;
         }
@@ -111,6 +127,31 @@ function renderPlugins(plugins) {
         `;
     }
 
+    const uncategorizedPlugins = normalizedPlugins.filter((plugin) => !KNOWN_CATEGORY_KEYS.has(plugin.category));
+    if (uncategorizedPlugins.length) {
+        html += `
+            <div class="mb-6">
+                <h3 class="text-lg font-semibold mb-3 flex items-center">
+                    <svg class="w-5 h-5 mr-2 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5h16M4 12h16M4 19h16"></path>
+                    </svg>
+                    Other Plugins
+                </h3>
+                <p class="text-sm text-gray-400 mb-3">These plugins use a custom category and may provide their own workflows.</p>
+                ${uncategorizedPlugins.map((plugin) => renderPluginCard(plugin)).join('')}
+            </div>
+        `;
+    }
+
+    if (!html) {
+        setContainerNode(createEmptyState({
+            title: 'No plugins available',
+            containerClass: 'text-center py-10',
+            titleClass: 'text-gray-500',
+        }));
+        return;
+    }
+
     container.innerHTML = html;
     bindPluginActions(container);
 }
@@ -119,6 +160,7 @@ function renderPluginCard(plugin) {
     const statusValue = String(plugin.status || 'unconfigured');
     const statusCss = statusClass(statusValue);
     const pluginId = String(plugin.id || '');
+    const hasPluginId = pluginId.length > 0;
     const categoryLink = CATEGORY_LINKS[plugin.category] || '';
 
     return `
@@ -132,6 +174,7 @@ function renderPluginCard(plugin) {
                     <p class="text-sm text-gray-400 mb-2">${escapeHtml(plugin.description || '')}</p>
                     <p class="text-xs text-gray-500">Version ${escapeHtml(plugin.version || 'unknown')}</p>
                     ${plugin.source ? `<p class="text-xs text-gray-500 mt-1">Source: ${escapeHtml(plugin.source)}</p>` : ''}
+                    ${!hasPluginId ? '<p class="text-xs text-yellow-400 mt-2">Plugin ID missing; management actions unavailable.</p>' : ''}
 
                     ${!plugin.installed ? `
                         <div class="mt-3 p-3 bg-yellow-900/20 border border-yellow-800 rounded">
@@ -148,7 +191,7 @@ function renderPluginCard(plugin) {
                 </div>
 
                 <div class="flex items-center gap-4 ml-4">
-                    ${plugin.type && plugin.type !== 'builtin' ? `
+                    ${hasPluginId && plugin.type && plugin.type !== 'builtin' ? `
                         <button type="button"
                                 class="text-xs text-red-300 hover:text-red-200 js-remove-plugin"
                                 data-plugin-id="${encodeDataAttr(pluginId)}">
@@ -159,6 +202,7 @@ function renderPluginCard(plugin) {
                         <input type="checkbox"
                                class="js-plugin-toggle"
                                data-plugin-id="${encodeDataAttr(pluginId)}"
+                               ${hasPluginId ? '' : 'disabled'}
                                ${plugin.enabled ? 'checked' : ''}>
                         <span class="toggle-slider"></span>
                     </label>

--- a/static/js/pages/plugins.js
+++ b/static/js/pages/plugins.js
@@ -1,7 +1,9 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
 import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { escapeHtml, encodeDataAttr } from '/js/lib/format.js';
+import { showNotification } from '/js/lib/notify.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -35,50 +37,10 @@ const CATEGORY_SECTIONS = [
     },
 ];
 
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
-
 function statusClass(status) {
     if (status === 'healthy') return 'status-healthy';
     if (status === 'error') return 'status-error';
     return 'status-unconfigured';
-}
-
-function escapeHtml(str) {
-    if (!str) return '';
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function encodeDataAttr(value) {
-    return escapeHtml(String(value ?? ''));
-}
-
-function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    const notification = document.createElement('div');
-    notification.className = 'p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0';
-    if (type === 'success') notification.classList.add('bg-green-600');
-    else if (type === 'error') notification.classList.add('bg-red-600');
-    else notification.classList.add('bg-blue-600');
-    notification.textContent = message;
-    area.appendChild(notification);
-    setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        setTimeout(() => notification.remove(), 300);
-    }, 3000);
 }
 
 function setContainerNode(node) {
@@ -98,7 +60,7 @@ async function loadPlugins() {
     }));
 
     try {
-        const response = await apiFetch('/api/storage/plugins');
+        const response = await requestApiResponse('/api/storage/plugins');
         const payload = await response.json();
         if (!response.ok) {
             throw new Error(payload?.error || `Failed to load plugins (${response.status})`);
@@ -232,7 +194,7 @@ async function togglePlugin(pluginId, enabled) {
     }
 
     try {
-        const response = await apiFetch(`/api/storage/plugins/${encodeURIComponent(pluginId)}/toggle`, {
+        const response = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}/toggle`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled }),
@@ -303,7 +265,7 @@ async function submitInstall() {
     const payload = Object.fromEntries(formData.entries());
 
     try {
-        const response = await apiFetch('/api/storage/plugins/install', {
+        const response = await requestApiResponse('/api/storage/plugins/install', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
@@ -332,7 +294,7 @@ async function removePlugin(pluginId) {
     }
 
     try {
-        const response = await apiFetch(`/api/storage/plugins/${encodeURIComponent(pluginId)}/remove`, {
+        const response = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}/remove`, {
             method: 'DELETE',
         });
         const data = await response.json().catch(() => ({}));
@@ -347,12 +309,34 @@ async function removePlugin(pluginId) {
     }
 }
 
-Object.assign(window, {
-    openInstallModal,
-    closeInstallModal,
-    toggleInstallType,
-    submitInstall,
-});
+function bindPluginPageActions() {
+    const openButton = document.getElementById('plugin-open-install');
+    if (openButton) {
+        openButton.addEventListener('click', openInstallModal);
+    }
+
+    const closeTopButton = document.getElementById('plugin-close-install-top');
+    if (closeTopButton) {
+        closeTopButton.addEventListener('click', closeInstallModal);
+    }
+
+    const closeBottomButton = document.getElementById('plugin-close-install-bottom');
+    if (closeBottomButton) {
+        closeBottomButton.addEventListener('click', closeInstallModal);
+    }
+
+    const installTypeSelect = document.getElementById('plugin-install-type');
+    if (installTypeSelect) {
+        installTypeSelect.addEventListener('change', (event) => {
+            toggleInstallType(event.target.value);
+        });
+    }
+
+    const submitButton = document.getElementById('plugin-submit-install');
+    if (submitButton) {
+        submitButton.addEventListener('click', submitInstall);
+    }
+}
 
 (async function initPluginsPage() {
     const authenticated = await ensureAuthenticated();
@@ -361,5 +345,6 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    bindPluginPageActions();
     await loadPlugins();
 })();

--- a/static/js/pages/plugins.js
+++ b/static/js/pages/plugins.js
@@ -1,7 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearClientSession } from '/js/lib/session.js';
-import { clearElement, createEmptyState, createErrorState } from '/js/lib/states.js';
+import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -91,6 +91,12 @@ function setContainerNode(node) {
 }
 
 async function loadPlugins() {
+    setContainerNode(createLoadingState({
+        message: 'Loading plugins...',
+        containerClass: 'text-center py-10',
+        messageClass: 'text-gray-400',
+    }));
+
     try {
         const response = await apiFetch('/api/storage/plugins');
         const payload = await response.json();

--- a/static/js/pages/pools.js
+++ b/static/js/pages/pools.js
@@ -1,6 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearClientSession } from '/js/lib/session.js';
+import { clearElement, createEmptyState, createLoadingState } from '/js/lib/states.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -26,6 +27,15 @@ let currentPluginSchema = null;
 let snapraidLogTagsByPlugin = {};
 let snapraidProgressState = {};
 let snapraidSyncContext = null;
+
+function setNodeContent(containerId, node) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    clearElement(container);
+    container.appendChild(node);
+}
 
 function showNotification(message, type = 'info') {
     const area = document.getElementById('notification-area');
@@ -58,6 +68,12 @@ function encodeDataAttr(value) {
 }
 
 async function loadPage() {
+    setNodeContent('pool-plugins', createLoadingState({
+        message: 'Loading storage plugins...',
+        containerClass: 'text-center py-10',
+        messageClass: 'text-gray-400',
+    }));
+
     const res = await apiFetch('/api/storage/plugins');
     const data = await res.json();
 
@@ -76,12 +92,13 @@ async function renderPoolPluginSections() {
     const container = document.getElementById('pool-plugins');
 
     if (!poolPlugins.length) {
-        container.innerHTML = `
-            <div class="text-center py-10">
-                <p class="text-gray-500 mb-2">No storage plugins enabled.</p>
-                <a href="/plugins.html" class="text-purple-400 hover:underline">Enable plugins &rarr;</a>
-            </div>
-        `;
+        setNodeContent('pool-plugins', createEmptyState({
+            title: 'No storage plugins enabled.',
+            action: { href: '/plugins.html', label: 'Enable plugins →' },
+            containerClass: 'text-center py-10',
+            titleClass: 'text-gray-500 mb-2',
+            actionClass: 'text-purple-400 hover:underline',
+        }));
         updatePoolFilterVisibility(false);
         return;
     }

--- a/static/js/pages/pools.js
+++ b/static/js/pages/pools.js
@@ -1,6 +1,6 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { createEmptyState, createLoadingState } from '/js/lib/states.js';
+import { createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 import { requestApiResponse } from '/js/lib/http.js';
 import { escapeHtml, encodeDataAttr } from '/js/lib/format.js';
 import { showNotification } from '/js/lib/notify.js';
@@ -21,6 +21,21 @@ let snapraidLogTagsByPlugin = {};
 let snapraidProgressState = {};
 let snapraidSyncContext = null;
 
+function normalizeStoragePlugins(rawPlugins) {
+    if (!Array.isArray(rawPlugins)) {
+        return [];
+    }
+
+    return rawPlugins
+        .filter((plugin) => plugin && typeof plugin === 'object')
+        .map((plugin) => ({
+            ...plugin,
+            id: typeof plugin.id === 'string' ? plugin.id.trim() : '',
+            category: typeof plugin.category === 'string' ? plugin.category : '',
+        }))
+        .filter((plugin) => plugin.id && plugin.category === 'storage' && plugin.enabled);
+}
+
 async function loadPage() {
     setNodeContent('pool-plugins', createLoadingState({
         message: 'Loading storage plugins...',
@@ -28,18 +43,27 @@ async function loadPage() {
         messageClass: 'text-gray-400',
     }));
 
-    const res = await requestApiResponse('/api/storage/plugins');
-    const data = await res.json();
+    try {
+        const res = await requestApiResponse('/api/storage/plugins');
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || `Failed to load plugins (${res.status})`);
+        }
 
-    // Filter to storage-category plugins that are enabled
-    poolPlugins = (data.plugins || []).filter(p =>
-        p.category === 'storage' && p.enabled
-    );
+        poolPlugins = normalizeStoragePlugins(data.plugins);
 
-    if (poolPlugins.length && currentPoolFilter !== "all" && !poolPlugins.find(p => p.id === currentPoolFilter)) {
-        currentPoolFilter = poolPlugins[0].id;
+        if (poolPlugins.length && currentPoolFilter !== "all" && !poolPlugins.find((plugin) => plugin.id === currentPoolFilter)) {
+            currentPoolFilter = poolPlugins[0].id;
+        }
+        await renderPoolPluginSections();
+    } catch (error) {
+        setNodeContent('pool-plugins', createErrorState({
+            title: `Failed to load storage plugins: ${error.message}`,
+            containerClass: 'text-center py-10',
+            titleClass: 'text-red-400',
+        }));
+        updatePoolFilterVisibility(false);
     }
-    await renderPoolPluginSections();
 }
 
 async function renderPoolPluginSections() {
@@ -64,27 +88,43 @@ async function renderPoolPluginSections() {
         // Fetch full plugin details
         let details = { status: { status: 'unknown' }, commands: [] };
         try {
-            const res = await requestApiResponse(`/api/storage/plugins/${plugin.id}`);
-            details = await res.json();
+            const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(plugin.id)}`);
+            const payload = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                throw new Error(payload.error || `Failed to load plugin details (${res.status})`);
+            }
+            details = payload;
             pluginDetailsMap[plugin.id] = details;
         } catch (e) {
             console.error(`Failed to load ${plugin.id}:`, e);
         }
         if (plugin.id === 'snapraid') {
             try {
-                const res = await requestApiResponse(`/api/storage/plugins/${plugin.id}/recovery`);
-                recoveryMap[plugin.id] = await res.json();
+                const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(plugin.id)}/recovery`);
+                const payload = await res.json().catch(() => ({}));
+                recoveryMap[plugin.id] = res.ok ? payload : null;
             } catch (e) {
                 recoveryMap[plugin.id] = null;
             }
         }
+
+        const commands = Array.isArray(details.commands)
+            ? details.commands
+                .filter((cmd) => cmd && typeof cmd === 'object')
+                .map((cmd) => ({
+                    ...cmd,
+                    id: typeof cmd.id === 'string' ? cmd.id.trim() : '',
+                    name: typeof cmd.name === 'string' ? cmd.name : '',
+                }))
+                .filter((cmd) => cmd.id)
+            : [];
 
         const statusClass = details.status?.status === 'healthy' ? 'status-healthy' :
                            details.status?.status === 'degraded' ? 'status-degraded' :
                            details.status?.status === 'error' ? 'status-error' : 'status-unconfigured';
 
         html += `
-            <section class="pool-plugin-section bg-gray-800 border border-purple-900/40 rounded-lg p-5 mb-6" data-plugin-id="${plugin.id}">
+            <section class="pool-plugin-section bg-gray-800 border border-purple-900/40 rounded-lg p-5 mb-6" data-plugin-id="${encodeDataAttr(plugin.id)}">
                 <div class="flex items-center justify-between mb-4">
                     <div>
                         <h3 class="text-lg font-semibold">${escapeHtml(plugin.name)}</h3>
@@ -106,15 +146,15 @@ async function renderPoolPluginSections() {
 
                     <!-- Plugin commands -->
                     <div class="flex flex-wrap gap-2">
-                        ${(details.commands || []).map(cmd => `
+                        ${commands.map(cmd => `
                             <button
                                     type="button"
                                     class="coraline-button py-2 px-4 rounded text-sm js-run-command"
                                     data-plugin-id="${encodeDataAttr(plugin.id)}"
                                     data-command-id="${encodeDataAttr(cmd.id)}"
-                                    data-command-name="${encodeDataAttr(cmd.name)}"
+                                    data-command-name="${encodeDataAttr(cmd.name || cmd.id)}"
                                     data-command-params="${encodeDataAttr(JSON.stringify(cmd.params || []))}">
-                                ${escapeHtml(cmd.name)}
+                                ${escapeHtml(cmd.name || cmd.id)}
                             </button>
                         `).join('')}
                         ${(plugin.id === 'snapraid' && recoveryMap[plugin.id]?.recovery_options?.length) ? `
@@ -198,7 +238,7 @@ function renderPoolFilterOptions() {
     if (!select) return;
     const options = [
         '<option value="all">All</option>',
-        ...poolPlugins.map(plugin => `<option value="${plugin.id}">${escapeHtml(plugin.name)}</option>`)
+        ...poolPlugins.map(plugin => `<option value="${encodeDataAttr(plugin.id)}">${escapeHtml(plugin.name)}</option>`)
     ];
     select.innerHTML = options.join('');
     select.value = currentPoolFilter;
@@ -400,11 +440,18 @@ async function executePluginCommand(pluginId, commandId, commandName, payload) {
             requestPayload.log_tags = true;
             requestPayload.stream_tags = true;
         }
-        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}/commands/${commandId}`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}/commands/${encodeURIComponent(commandId)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(requestPayload)
         });
+        if (!res.ok) {
+            const errorPayload = await res.json().catch(() => ({}));
+            throw new Error(errorPayload.error || `Command failed (${res.status})`);
+        }
+        if (!res.body) {
+            throw new Error('Command output stream unavailable');
+        }
 
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
@@ -600,11 +647,14 @@ function buildSnapraidSyncWarning(pluginId, summary) {
 
 async function fetchSnapraidDiffSummary(pluginId) {
     try {
-        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}/commands/diff`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}/commands/diff`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ log_tags: true })
         });
+        if (!res.ok || !res.body) {
+            return null;
+        }
 
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
@@ -695,8 +745,11 @@ async function openConfigModal(pluginId) {
     currentPlugin = pluginId;
 
     try {
-        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}`);
-        const data = await res.json();
+        const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}`);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || `Failed to load config (${res.status})`);
+        }
         currentPluginSchema = data.schema;
         renderConfigForm(data.schema, data.config || {});
         document.getElementById('config-modal-title').textContent = `Configure ${data.name}`;

--- a/static/js/pages/pools.js
+++ b/static/js/pages/pools.js
@@ -1,22 +1,15 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
-import { clearElement, createEmptyState, createLoadingState } from '/js/lib/states.js';
+import { createEmptyState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { escapeHtml, encodeDataAttr } from '/js/lib/format.js';
+import { showNotification } from '/js/lib/notify.js';
+import { setNodeContent } from '/js/lib/dom.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
     includeFooter: true,
 });
-
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
 
 let poolPlugins = [];
 let pluginDetailsMap = {};
@@ -28,45 +21,6 @@ let snapraidLogTagsByPlugin = {};
 let snapraidProgressState = {};
 let snapraidSyncContext = null;
 
-function setNodeContent(containerId, node) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-        return;
-    }
-    clearElement(container);
-    container.appendChild(node);
-}
-
-function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    const notification = document.createElement('div');
-    notification.className = 'p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0';
-    if (type === 'success') notification.classList.add('bg-green-600');
-    else if (type === 'error') notification.classList.add('bg-red-600');
-    else notification.classList.add('bg-blue-600');
-    notification.textContent = message;
-    area.appendChild(notification);
-    setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        setTimeout(() => notification.remove(), 300);
-    }, 3000);
-}
-
-function escapeHtml(str) {
-    if (!str) return '';
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function encodeDataAttr(value) {
-    return escapeHtml(String(value ?? ''));
-}
-
 async function loadPage() {
     setNodeContent('pool-plugins', createLoadingState({
         message: 'Loading storage plugins...',
@@ -74,7 +28,7 @@ async function loadPage() {
         messageClass: 'text-gray-400',
     }));
 
-    const res = await apiFetch('/api/storage/plugins');
+    const res = await requestApiResponse('/api/storage/plugins');
     const data = await res.json();
 
     // Filter to storage-category plugins that are enabled
@@ -110,7 +64,7 @@ async function renderPoolPluginSections() {
         // Fetch full plugin details
         let details = { status: { status: 'unknown' }, commands: [] };
         try {
-            const res = await apiFetch(`/api/storage/plugins/${plugin.id}`);
+            const res = await requestApiResponse(`/api/storage/plugins/${plugin.id}`);
             details = await res.json();
             pluginDetailsMap[plugin.id] = details;
         } catch (e) {
@@ -118,7 +72,7 @@ async function renderPoolPluginSections() {
         }
         if (plugin.id === 'snapraid') {
             try {
-                const res = await apiFetch(`/api/storage/plugins/${plugin.id}/recovery`);
+                const res = await requestApiResponse(`/api/storage/plugins/${plugin.id}/recovery`);
                 recoveryMap[plugin.id] = await res.json();
             } catch (e) {
                 recoveryMap[plugin.id] = null;
@@ -233,6 +187,10 @@ function bindPoolPluginActions() {
             }
         });
     });
+
+    container.querySelectorAll('.js-view-snapraid-log').forEach((button) => {
+        button.addEventListener('click', viewSnapraidLog);
+    });
 }
 
 function renderPoolFilterOptions() {
@@ -296,7 +254,7 @@ function renderPluginStatus(pluginId, status, recovery) {
         ` : '';
 
         const logLink = status?.details?.last_log_path ? `
-            <button onclick="viewSnapraidLog()" class="mt-3 text-xs text-purple-300 hover:text-purple-200">
+            <button type="button" class="js-view-snapraid-log mt-3 text-xs text-purple-300 hover:text-purple-200">
                 View last log
             </button>
         ` : '';
@@ -407,7 +365,7 @@ async function viewSnapraidLog() {
     progressPanel.classList.add('hidden');
 
     try {
-        const res = await apiFetch('/api/storage/plugins/snapraid/logs/latest');
+        const res = await requestApiResponse('/api/storage/plugins/snapraid/logs/latest');
         if (!res.ok) {
             content.textContent = 'No log available.';
             return;
@@ -442,7 +400,7 @@ async function executePluginCommand(pluginId, commandId, commandName, payload) {
             requestPayload.log_tags = true;
             requestPayload.stream_tags = true;
         }
-        const res = await apiFetch(`/api/storage/plugins/${pluginId}/commands/${commandId}`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}/commands/${commandId}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(requestPayload)
@@ -642,7 +600,7 @@ function buildSnapraidSyncWarning(pluginId, summary) {
 
 async function fetchSnapraidDiffSummary(pluginId) {
     try {
-        const res = await apiFetch(`/api/storage/plugins/${pluginId}/commands/diff`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}/commands/diff`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ log_tags: true })
@@ -737,7 +695,7 @@ async function openConfigModal(pluginId) {
     currentPlugin = pluginId;
 
     try {
-        const res = await apiFetch(`/api/storage/plugins/${pluginId}`);
+        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}`);
         const data = await res.json();
         currentPluginSchema = data.schema;
         renderConfigForm(data.schema, data.config || {});
@@ -771,14 +729,18 @@ function renderConfigForm(schema, values) {
                     <label class="block text-sm text-gray-300 mb-1">${escapeHtml(description)}</label>
                     <div id="array-${key}" class="space-y-2">
                         ${items.map((item, i) => `
-                            <div class="flex gap-2">
+                            <div class="flex gap-2 js-array-item-row">
                                 <input type="text" name="${key}[]" value="${escapeHtml(String(item))}"
                                        class="flex-1 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm">
-                                <button type="button" onclick="removeArrayItem('${key}', ${i})" class="px-2 text-red-400 hover:text-red-300">&times;</button>
+                                <button type="button"
+                                        class="js-remove-array-item px-2 text-red-400 hover:text-red-300"
+                                        data-array-key="${encodeDataAttr(key)}">&times;</button>
                             </div>
                         `).join('')}
                     </div>
-                    <button type="button" onclick="addArrayItem('${key}')" class="mt-2 text-sm text-purple-400 hover:text-purple-300">+ Add</button>
+                    <button type="button"
+                            class="js-add-array-item mt-2 text-sm text-purple-400 hover:text-purple-300"
+                            data-array-key="${encodeDataAttr(key)}">+ Add</button>
                 </div>
             `;
         } else if (prop.type === 'boolean') {
@@ -838,7 +800,7 @@ function renderMergerFSConfigForm(schema, values) {
                 <div class="text-sm text-gray-400">
                     Configure MergerFS pools. Branches and mount points should be under /mnt/.
                 </div>
-                <button type="button" onclick="addMergerFSPool()" class="text-sm text-purple-400 hover:text-purple-300">+ Add Pool</button>
+                <button type="button" class="js-add-mergerfs-pool text-sm text-purple-400 hover:text-purple-300">+ Add Pool</button>
             </div>
             <div id="mergerfs-pools" class="space-y-4">
                 ${poolCards || '<p class="text-gray-500">No pools configured</p>'}
@@ -867,7 +829,7 @@ function renderMergerFSPoolCard(pool, idx) {
         <div class="flex gap-2 mergerfs-branch-row">
             <input type="text" name="branches[]" value="${escapeHtml(String(branch))}"
                    class="flex-1 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm">
-            <button type="button" onclick="removeMergerFSBranch(this)" class="px-2 text-red-400 hover:text-red-300">&times;</button>
+            <button type="button" class="js-remove-mergerfs-branch px-2 text-red-400 hover:text-red-300">&times;</button>
         </div>
     `).join('');
 
@@ -882,7 +844,7 @@ function renderMergerFSPoolCard(pool, idx) {
         <div class="bg-gray-900 border border-purple-900/40 rounded p-4 mergerfs-pool">
             <div class="flex items-center justify-between mb-3">
                 <h4 class="text-sm font-semibold text-gray-200">Pool ${idx + 1}</h4>
-                <button type="button" onclick="removeMergerFSPool(this)" class="text-xs text-red-300 hover:text-red-200">Remove</button>
+                <button type="button" class="js-remove-mergerfs-pool text-xs text-red-300 hover:text-red-200">Remove</button>
             </div>
             <input type="hidden" name="pool_id" value="${escapeHtml(String(poolId))}">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
@@ -926,11 +888,11 @@ function renderMergerFSPoolCard(pool, idx) {
                         <div class="flex gap-2 mergerfs-branch-row">
                             <input type="text" name="branches[]" value=""
                                    class="flex-1 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm">
-                            <button type="button" onclick="removeMergerFSBranch(this)" class="px-2 text-red-400 hover:text-red-300">&times;</button>
+                            <button type="button" class="js-remove-mergerfs-branch px-2 text-red-400 hover:text-red-300">&times;</button>
                         </div>
                     `}
                 </div>
-                <button type="button" onclick="addMergerFSBranch(this)" class="mt-2 text-sm text-purple-400 hover:text-purple-300">+ Add Branch</button>
+                <button type="button" class="js-add-mergerfs-branch mt-2 text-sm text-purple-400 hover:text-purple-300">+ Add Branch</button>
             </div>
             <div class="flex items-center gap-3">
                 <input type="checkbox" name="enabled" ${enabled ? 'checked' : ''} class="w-4 h-4 rounded">
@@ -975,7 +937,7 @@ function addMergerFSBranch(button) {
     row.innerHTML = `
         <input type="text" name="branches[]" value=""
                class="flex-1 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm">
-        <button type="button" onclick="removeMergerFSBranch(this)" class="px-2 text-red-400 hover:text-red-300">&times;</button>
+        <button type="button" class="js-remove-mergerfs-branch px-2 text-red-400 hover:text-red-300">&times;</button>
     `;
     container.appendChild(row);
 }
@@ -987,22 +949,22 @@ function removeMergerFSBranch(button) {
 
 function addArrayItem(key) {
     const container = document.getElementById(`array-${key}`);
-    const idx = container.children.length;
+    if (!container) return;
     const div = document.createElement('div');
-    div.className = 'flex gap-2';
+    div.className = 'flex gap-2 js-array-item-row';
     div.innerHTML = `
         <input type="text" name="${key}[]" value=""
                class="flex-1 bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white text-sm">
-        <button type="button" onclick="removeArrayItem('${key}', ${idx})" class="px-2 text-red-400 hover:text-red-300">&times;</button>
+        <button type="button"
+                class="js-remove-array-item px-2 text-red-400 hover:text-red-300"
+                data-array-key="${encodeDataAttr(key)}">&times;</button>
     `;
     container.appendChild(div);
 }
 
-function removeArrayItem(key, idx) {
-    const container = document.getElementById(`array-${key}`);
-    if (container.children[idx]) {
-        container.children[idx].remove();
-    }
+function removeArrayItem(button) {
+    const row = button?.closest('.js-array-item-row');
+    if (row) row.remove();
 }
 
 function closeConfigModal() {
@@ -1075,7 +1037,7 @@ async function saveConfig() {
     const formData = getFormData();
 
     try {
-        const res = await apiFetch(`/api/storage/plugins/${currentPlugin}/config`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${currentPlugin}/config`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(formData)
@@ -1092,7 +1054,7 @@ async function saveConfig() {
 
 async function applyConfig() {
     try {
-        const res = await apiFetch(`/api/storage/plugins/${currentPlugin}/apply`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${currentPlugin}/apply`, {
             method: 'POST'
         });
         const data = await res.json();
@@ -1104,27 +1066,107 @@ async function applyConfig() {
     }
 }
 
-Object.assign(window, {
-    setPoolFilter,
-    runPluginCommand,
-    runSnapraidRecovery,
-    viewSnapraidLog,
-    closeOutputModal,
-    closeCommandParamModal,
-    confirmCommandParams,
-    closeSnapraidSyncModal,
-    confirmSnapraidSync,
-    openConfigModal,
-    closeConfigModal,
-    saveConfig,
-    applyConfig,
-    addMergerFSPool,
-    removeMergerFSPool,
-    addMergerFSBranch,
-    removeMergerFSBranch,
-    addArrayItem,
-    removeArrayItem,
-});
+function bindPoolFilterActions() {
+    const select = document.getElementById('pool-filter');
+    if (!select) return;
+
+    select.addEventListener('change', () => {
+        setPoolFilter(select.value);
+    });
+}
+
+function bindPoolModalActions() {
+    document.addEventListener('click', (event) => {
+        const actionTrigger = event.target.closest('[data-action]');
+        if (actionTrigger) {
+            const { action } = actionTrigger.dataset;
+            switch (action) {
+            case 'close-output-modal':
+                closeOutputModal();
+                break;
+            case 'close-command-param-modal':
+                closeCommandParamModal();
+                break;
+            case 'confirm-command-params':
+                confirmCommandParams();
+                break;
+            case 'close-snapraid-sync-modal':
+                closeSnapraidSyncModal();
+                break;
+            case 'confirm-snapraid-sync':
+                confirmSnapraidSync();
+                break;
+            case 'close-config-modal':
+                closeConfigModal();
+                break;
+            case 'save-config':
+                saveConfig();
+                break;
+            case 'apply-config':
+                applyConfig();
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (event.target instanceof HTMLElement && event.target.matches('[data-overlay-close]')) {
+            const modalId = event.target.dataset.overlayClose;
+            if (modalId) {
+                document.getElementById(modalId)?.classList.add('hidden');
+            }
+
+            if (modalId === 'command-param-modal') {
+                pendingCommand = null;
+            } else if (modalId === 'snapraid-sync-modal') {
+                snapraidSyncContext = null;
+            } else if (modalId === 'config-modal') {
+                currentPlugin = null;
+                currentPluginSchema = null;
+            }
+        }
+    });
+}
+
+function bindPoolConfigFormActions() {
+    document.addEventListener('click', (event) => {
+        const addArrayButton = event.target.closest('.js-add-array-item');
+        if (addArrayButton) {
+            const key = addArrayButton.dataset.arrayKey || '';
+            if (key) addArrayItem(key);
+            return;
+        }
+
+        const removeArrayButton = event.target.closest('.js-remove-array-item');
+        if (removeArrayButton) {
+            removeArrayItem(removeArrayButton);
+            return;
+        }
+
+        const addPoolButton = event.target.closest('.js-add-mergerfs-pool');
+        if (addPoolButton) {
+            addMergerFSPool();
+            return;
+        }
+
+        const removePoolButton = event.target.closest('.js-remove-mergerfs-pool');
+        if (removePoolButton) {
+            removeMergerFSPool(removePoolButton);
+            return;
+        }
+
+        const addBranchButton = event.target.closest('.js-add-mergerfs-branch');
+        if (addBranchButton) {
+            addMergerFSBranch(addBranchButton);
+            return;
+        }
+
+        const removeBranchButton = event.target.closest('.js-remove-mergerfs-branch');
+        if (removeBranchButton) {
+            removeMergerFSBranch(removeBranchButton);
+        }
+    });
+}
 
 (async function initPoolsPage() {
     const authenticated = await ensureAuthenticated();
@@ -1133,5 +1175,8 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    bindPoolFilterActions();
+    bindPoolModalActions();
+    bindPoolConfigFormActions();
     await loadPage();
 })();

--- a/static/js/pages/settings.js
+++ b/static/js/pages/settings.js
@@ -1,8 +1,8 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearElement } from '/js/lib/states.js';
-import { requestJson } from '/js/lib/http.js';
-import { clearClientSession } from '/js/lib/session.js';
+import { requestApiJson, requestApiResponse } from '/js/lib/http.js';
+import { showNotification } from '/js/lib/notify.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 space-y-2',
@@ -14,56 +14,17 @@ let backupConfig = {};
 let logsVisible = false;
 let pihealthUpdateConfig = {};
 
-function showNotification(message, type = 'info') {
-    const notificationArea = document.getElementById('notification-area');
-    if (!notificationArea) {
-        return;
-    }
-
-    const notification = document.createElement('div');
-    notification.className = 'notification transform transition-all duration-500 opacity-0';
-
-    if (type === 'success') {
-        notification.classList.add('bg-green-600');
-    } else if (type === 'error') {
-        notification.classList.add('bg-red-600');
-    } else {
-        notification.classList.add('bg-blue-600');
-    }
-
-    notification.textContent = message;
-    notificationArea.appendChild(notification);
-
-    window.setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    window.setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        window.setTimeout(() => notification.remove(), 500);
-    }, 3000);
-}
-
 async function requestApi(url, options = {}) {
-    const { response, payload } = await requestJson(url, options);
+    const response = await requestApiResponse(url, options);
+    let payload = {};
 
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
+    try {
+        payload = await response.json();
+    } catch (_err) {
+        payload = {};
     }
 
-    return { response, payload: payload || {} };
-}
-
-async function requestApiJson(url, options = {}) {
-    const { response, payload } = await requestApi(url, options);
-
-    if (!response.ok) {
-        const err = new Error(payload.error || payload.stderr || `Request failed (${response.status})`);
-        err.status = response.status;
-        err.data = payload;
-        throw err;
-    }
-
-    return payload;
+    return { response, payload };
 }
 
 function setButtonBusy(button, busy) {

--- a/static/js/pages/settings.js
+++ b/static/js/pages/settings.js
@@ -1,5 +1,6 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
+import { clearClientSession } from '/js/lib/session.js';
 import { clearElement } from '/js/lib/states.js';
 import { requestApiJson, requestApiResponse } from '/js/lib/http.js';
 import { showNotification } from '/js/lib/notify.js';

--- a/static/js/pages/shares.js
+++ b/static/js/pages/shares.js
@@ -13,6 +13,21 @@ ensureDashboardShell({
 
 let sharePlugins = [];
 
+function normalizeSharePlugins(rawPlugins) {
+    if (!Array.isArray(rawPlugins)) {
+        return [];
+    }
+
+    return rawPlugins
+        .filter((plugin) => plugin && typeof plugin === 'object')
+        .map((plugin) => ({
+            ...plugin,
+            id: typeof plugin.id === 'string' ? plugin.id.trim() : '',
+            category: typeof plugin.category === 'string' ? plugin.category : '',
+        }))
+        .filter((plugin) => plugin.id && plugin.category === 'share' && plugin.enabled);
+}
+
 function showSharesLoading() {
     const loadingState = document.getElementById('loading-state');
     const sharesContent = document.getElementById('shares-content');
@@ -43,8 +58,11 @@ async function loadSharePlugins() {
 
     try {
         const res = await requestApiResponse('/api/storage/plugins');
-        const data = await res.json();
-        sharePlugins = (data.plugins || []).filter(p => p.category === 'share' && p.enabled);
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            throw new Error(data.error || `Failed to load plugins (${res.status})`);
+        }
+        sharePlugins = normalizeSharePlugins(data.plugins);
 
         document.getElementById('loading-state').classList.add('hidden');
         document.getElementById('shares-content').classList.remove('hidden');
@@ -78,8 +96,12 @@ async function renderSharePlugins() {
         // Fetch detailed share info
         let shareData = { shares: [], service_running: false, status: 'unknown' };
         try {
-            const res = await requestApiResponse(`/api/storage/shares/${plugin.id}`);
-            shareData = await res.json();
+            const res = await requestApiResponse(`/api/storage/shares/${encodeURIComponent(plugin.id)}`);
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                throw new Error(data.error || `Failed to load shares (${res.status})`);
+            }
+            shareData = data;
         } catch (e) {
             console.error(`Failed to load shares for ${plugin.id}:`, e);
         }
@@ -315,13 +337,13 @@ async function saveShare(event) {
     try {
         let res;
         if (isEdit) {
-            res = await requestApiResponse(`/api/storage/shares/${pluginId}/${encodeURIComponent(originalName)}`, {
+            res = await requestApiResponse(`/api/storage/shares/${encodeURIComponent(pluginId)}/${encodeURIComponent(originalName)}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(share)
             });
         } else {
-            res = await requestApiResponse(`/api/storage/shares/${pluginId}`, {
+            res = await requestApiResponse(`/api/storage/shares/${encodeURIComponent(pluginId)}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(share)
@@ -343,7 +365,7 @@ async function saveShare(event) {
 
 async function toggleShare(pluginId, shareName, enabled) {
     try {
-        const res = await requestApiResponse(`/api/storage/shares/${pluginId}/${encodeURIComponent(shareName)}/toggle`, {
+        const res = await requestApiResponse(`/api/storage/shares/${encodeURIComponent(pluginId)}/${encodeURIComponent(shareName)}/toggle`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled })
@@ -368,7 +390,7 @@ async function deleteShare(pluginId, shareName) {
     }
 
     try {
-        const res = await requestApiResponse(`/api/storage/shares/${pluginId}/${encodeURIComponent(shareName)}`, {
+        const res = await requestApiResponse(`/api/storage/shares/${encodeURIComponent(pluginId)}/${encodeURIComponent(shareName)}`, {
             method: 'DELETE'
         });
 
@@ -385,6 +407,11 @@ async function deleteShare(pluginId, shareName) {
 }
 
 async function runPluginCommand(pluginId, commandId) {
+    if (!pluginId || !commandId) {
+        showNotification('Plugin command metadata is missing', 'error');
+        return;
+    }
+
     if (commandId === 'restart' && !confirm('Restart Samba service? This will briefly disconnect clients.')) {
         return;
     }
@@ -395,10 +422,17 @@ async function runPluginCommand(pluginId, commandId) {
     document.getElementById('output-modal').classList.remove('hidden');
 
     try {
-        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}/commands/${commandId}`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${encodeURIComponent(pluginId)}/commands/${encodeURIComponent(commandId)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
         });
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || `Command failed (${res.status})`);
+        }
+        if (!res.body) {
+            throw new Error('Command output stream unavailable');
+        }
 
         const reader = res.body.getReader();
         const decoder = new TextDecoder();

--- a/static/js/pages/shares.js
+++ b/static/js/pages/shares.js
@@ -1,33 +1,17 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
-import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { escapeHtml, encodeDataAttr } from '/js/lib/format.js';
+import { showNotification } from '/js/lib/notify.js';
+import { setNodeContent } from '/js/lib/dom.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
     includeFooter: true,
 });
 
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
-
 let sharePlugins = [];
-
-function setNodeContent(containerId, node) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-        return;
-    }
-    clearElement(container);
-    container.appendChild(node);
-}
 
 function showSharesLoading() {
     const loadingState = document.getElementById('loading-state');
@@ -54,43 +38,11 @@ function statusClass(status) {
     return 'status-unconfigured';
 }
 
-function escapeHtml(str) {
-    if (!str) return '';
-    return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function encodeDataAttr(value) {
-    return escapeHtml(String(value ?? ''));
-}
-
-function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    const colors = {
-        success: 'bg-green-600',
-        error: 'bg-red-600',
-        info: 'bg-blue-600'
-    };
-    const notification = document.createElement('div');
-    notification.className = `${colors[type] || colors.info} p-3 mb-2 rounded shadow-lg transform transition-all duration-300 opacity-0`;
-    notification.textContent = message;
-    area.appendChild(notification);
-    setTimeout(() => notification.classList.replace('opacity-0', 'opacity-100'), 10);
-    setTimeout(() => {
-        notification.classList.replace('opacity-100', 'opacity-0');
-        setTimeout(() => notification.remove(), 300);
-    }, 3000);
-}
-
 async function loadSharePlugins() {
     showSharesLoading();
 
     try {
-        const res = await apiFetch('/api/storage/plugins');
+        const res = await requestApiResponse('/api/storage/plugins');
         const data = await res.json();
         sharePlugins = (data.plugins || []).filter(p => p.category === 'share' && p.enabled);
 
@@ -126,7 +78,7 @@ async function renderSharePlugins() {
         // Fetch detailed share info
         let shareData = { shares: [], service_running: false, status: 'unknown' };
         try {
-            const res = await apiFetch(`/api/storage/shares/${plugin.id}`);
+            const res = await requestApiResponse(`/api/storage/shares/${plugin.id}`);
             shareData = await res.json();
         } catch (e) {
             console.error(`Failed to load shares for ${plugin.id}:`, e);
@@ -148,23 +100,23 @@ async function renderSharePlugins() {
                         <p class="text-sm text-gray-400">${escapeHtml(plugin.description)}</p>
                     </div>
                     <div class="flex gap-2">
-                        <button onclick="runPluginCommand(this.dataset.pluginId, this.dataset.commandId)"
+                        <button type="button"
+                                class="js-run-plugin-command px-3 py-1 text-sm border border-purple-700 text-purple-300 rounded hover:bg-purple-900"
                                 data-plugin-id="${encodeDataAttr(plugin.id)}"
                                 data-command-id="apply"
-                                class="px-3 py-1 text-sm border border-purple-700 text-purple-300 rounded hover:bg-purple-900"
                                 title="Generate configuration file">
                             Apply Config
                         </button>
-                        <button onclick="runPluginCommand(this.dataset.pluginId, this.dataset.commandId)"
+                        <button type="button"
+                                class="js-run-plugin-command px-3 py-1 text-sm border border-yellow-700 text-yellow-300 rounded hover:bg-yellow-900/30"
                                 data-plugin-id="${encodeDataAttr(plugin.id)}"
                                 data-command-id="restart"
-                                class="px-3 py-1 text-sm border border-yellow-700 text-yellow-300 rounded hover:bg-yellow-900/30"
                                 title="Restart Samba service">
                             Restart Service
                         </button>
-                        <button onclick="openAddShareModal(this.dataset.pluginId)"
+                        <button type="button"
+                                class="js-open-add-share coraline-button px-4 py-1 rounded text-sm"
                                 data-plugin-id="${encodeDataAttr(plugin.id)}"
-                                class="coraline-button px-4 py-1 rounded text-sm"
                                 ${!plugin.installed ? 'disabled title="Install Samba first"' : ''}>
                             + Add Share
                         </button>
@@ -189,6 +141,7 @@ async function renderSharePlugins() {
     }
 
     container.innerHTML = html;
+    bindSharePluginActions(container);
 }
 
 function renderShareCard(pluginId, share) {
@@ -226,28 +179,61 @@ function renderShareCard(pluginId, share) {
                 </div>
                 <div class="flex items-center gap-3 ml-4">
                     <label class="toggle-switch" title="${isEnabled ? 'Disable share' : 'Enable share'}">
-                        <input type="checkbox" ${isEnabled ? 'checked' : ''}
+                        <input type="checkbox" class="js-toggle-share" ${isEnabled ? 'checked' : ''}
                                data-plugin-id="${encodeDataAttr(pluginId)}"
-                               data-share-name="${encodeDataAttr(share.name)}"
-                               onchange="toggleShare(this.dataset.pluginId, this.dataset.shareName, this.checked)">
+                               data-share-name="${encodeDataAttr(share.name)}">
                         <span class="toggle-slider"></span>
                     </label>
                     <button data-plugin-id="${encodeDataAttr(pluginId)}"
+                            type="button"
                             data-share="${encodeDataAttr(encodeURIComponent(JSON.stringify(share)))}"
-                            onclick="openEditShareModalFromButton(this)"
-                            class="text-sm text-gray-400 hover:text-white px-2 py-1">
+                            class="js-open-edit-share text-sm text-gray-400 hover:text-white px-2 py-1">
                         Edit
                     </button>
-                    <button onclick="deleteShare(this.dataset.pluginId, this.dataset.shareName)"
+                    <button type="button"
+                            class="js-delete-share text-sm text-red-400 hover:text-red-300 px-2 py-1"
                             data-plugin-id="${encodeDataAttr(pluginId)}"
-                            data-share-name="${encodeDataAttr(share.name)}"
-                            class="text-sm text-red-400 hover:text-red-300 px-2 py-1">
+                            data-share-name="${encodeDataAttr(share.name)}">
                         Delete
                     </button>
                 </div>
             </div>
         </div>
     `;
+}
+
+function bindSharePluginActions(container) {
+    if (!container) return;
+
+    container.querySelectorAll('.js-run-plugin-command').forEach((button) => {
+        button.addEventListener('click', () => {
+            runPluginCommand(button.dataset.pluginId || '', button.dataset.commandId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-open-add-share').forEach((button) => {
+        button.addEventListener('click', () => {
+            openAddShareModal(button.dataset.pluginId || '');
+        });
+    });
+
+    container.querySelectorAll('.js-toggle-share').forEach((checkbox) => {
+        checkbox.addEventListener('change', () => {
+            toggleShare(checkbox.dataset.pluginId || '', checkbox.dataset.shareName || '', checkbox.checked);
+        });
+    });
+
+    container.querySelectorAll('.js-open-edit-share').forEach((button) => {
+        button.addEventListener('click', () => {
+            openEditShareModalFromButton(button);
+        });
+    });
+
+    container.querySelectorAll('.js-delete-share').forEach((button) => {
+        button.addEventListener('click', () => {
+            deleteShare(button.dataset.pluginId || '', button.dataset.shareName || '');
+        });
+    });
 }
 
 function openAddShareModal(pluginId) {
@@ -329,13 +315,13 @@ async function saveShare(event) {
     try {
         let res;
         if (isEdit) {
-            res = await apiFetch(`/api/storage/shares/${pluginId}/${encodeURIComponent(originalName)}`, {
+            res = await requestApiResponse(`/api/storage/shares/${pluginId}/${encodeURIComponent(originalName)}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(share)
             });
         } else {
-            res = await apiFetch(`/api/storage/shares/${pluginId}`, {
+            res = await requestApiResponse(`/api/storage/shares/${pluginId}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(share)
@@ -357,7 +343,7 @@ async function saveShare(event) {
 
 async function toggleShare(pluginId, shareName, enabled) {
     try {
-        const res = await apiFetch(`/api/storage/shares/${pluginId}/${encodeURIComponent(shareName)}/toggle`, {
+        const res = await requestApiResponse(`/api/storage/shares/${pluginId}/${encodeURIComponent(shareName)}/toggle`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled })
@@ -382,7 +368,7 @@ async function deleteShare(pluginId, shareName) {
     }
 
     try {
-        const res = await apiFetch(`/api/storage/shares/${pluginId}/${encodeURIComponent(shareName)}`, {
+        const res = await requestApiResponse(`/api/storage/shares/${pluginId}/${encodeURIComponent(shareName)}`, {
             method: 'DELETE'
         });
 
@@ -409,7 +395,7 @@ async function runPluginCommand(pluginId, commandId) {
     document.getElementById('output-modal').classList.remove('hidden');
 
     try {
-        const res = await apiFetch(`/api/storage/plugins/${pluginId}/commands/${commandId}`, {
+        const res = await requestApiResponse(`/api/storage/plugins/${pluginId}/commands/${commandId}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' }
         });
@@ -453,18 +439,28 @@ function closeOutputModal() {
     document.getElementById('output-modal').classList.add('hidden');
 }
 
-// Load on page load
+function bindSharePageActions() {
+    document.getElementById('share-form')?.addEventListener('submit', saveShare);
 
-Object.assign(window, {
-    closeShareModal,
-    saveShare,
-    closeOutputModal,
-    runPluginCommand,
-    openAddShareModal,
-    openEditShareModalFromButton,
-    toggleShare,
-    deleteShare,
-});
+    document.addEventListener('click', (event) => {
+        const trigger = event.target.closest('[data-action]');
+        if (trigger) {
+            const { action } = trigger.dataset;
+            if (action === 'close-share-modal') {
+                closeShareModal();
+            } else if (action === 'close-output-modal') {
+                closeOutputModal();
+            }
+        }
+
+        if (event.target instanceof HTMLElement && event.target.matches('[data-overlay-close]')) {
+            const modalId = event.target.dataset.overlayClose;
+            if (modalId) {
+                document.getElementById(modalId)?.classList.add('hidden');
+            }
+        }
+    });
+}
 
 (async function initSharesPage() {
     const authenticated = await ensureAuthenticated();
@@ -473,5 +469,6 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    bindSharePageActions();
     await loadSharePlugins();
 })();

--- a/static/js/pages/shares.js
+++ b/static/js/pages/shares.js
@@ -1,6 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearClientSession } from '/js/lib/session.js';
+import { clearElement, createEmptyState, createErrorState, createLoadingState } from '/js/lib/states.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -18,6 +19,33 @@ async function apiFetch(url, options = {}) {
 }
 
 let sharePlugins = [];
+
+function setNodeContent(containerId, node) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    clearElement(container);
+    container.appendChild(node);
+}
+
+function showSharesLoading() {
+    const loadingState = document.getElementById('loading-state');
+    const sharesContent = document.getElementById('shares-content');
+
+    if (loadingState) {
+        loadingState.classList.remove('hidden');
+    }
+    if (sharesContent) {
+        sharesContent.classList.add('hidden');
+    }
+
+    setNodeContent('loading-state', createLoadingState({
+        message: 'Loading share plugins...',
+        containerClass: 'text-center py-10',
+        messageClass: 'text-gray-400',
+    }));
+}
 
 function statusClass(status) {
     if (status === 'healthy') return 'status-healthy';
@@ -59,6 +87,8 @@ function showNotification(message, type = 'info') {
 }
 
 async function loadSharePlugins() {
+    showSharesLoading();
+
     try {
         const res = await apiFetch('/api/storage/plugins');
         const data = await res.json();
@@ -68,19 +98,23 @@ async function loadSharePlugins() {
         document.getElementById('shares-content').classList.remove('hidden');
 
         if (sharePlugins.length === 0) {
-            document.getElementById('shares-content').innerHTML = `
-                <div class="bg-gray-800 border border-purple-900/40 rounded-lg p-6 text-center">
-                    <p class="text-gray-400 mb-4">No share plugins enabled.</p>
-                    <a href="/plugins.html" class="text-purple-400 hover:underline">Enable plugins on the Plugins page</a>
-                </div>
-            `;
+            setNodeContent('shares-content', createEmptyState({
+                title: 'No share plugins enabled.',
+                action: { href: '/plugins.html', label: 'Enable plugins on the Plugins page' },
+                containerClass: 'bg-gray-800 border border-purple-900/40 rounded-lg p-6 text-center',
+                titleClass: 'text-gray-400 mb-4',
+                actionClass: 'text-purple-400 hover:underline',
+            }));
             return;
         }
 
         await renderSharePlugins();
     } catch (e) {
-        document.getElementById('loading-state').innerHTML =
-            `<p class="text-red-400">Failed to load shares: ${e.message}</p>`;
+        setNodeContent('loading-state', createErrorState({
+            title: `Failed to load shares: ${e.message}`,
+            containerClass: 'text-center py-10',
+            titleClass: 'text-red-400',
+        }));
     }
 }
 

--- a/static/js/pages/stacks.js
+++ b/static/js/pages/stacks.js
@@ -1,7 +1,8 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearElement, createEmptyState, createErrorState } from '/js/lib/states.js';
-import { requestJson } from '/js/lib/http.js';
+import { requestApiJson } from '/js/lib/http.js';
+import { showNotification } from '/js/lib/notify.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -13,29 +14,6 @@ let currentStack = null;
 let eventSource = null;
 let editComposeEditor = null;
 let newComposeEditor = null;
-
-function showNotification(message, type = 'info') {
-    if (typeof window.showToast === 'function') {
-        window.showToast(message, type);
-        return;
-    }
-    console.log(`[${type}] ${message}`);
-}
-
-async function requestApiJson(url, options = {}) {
-    const { response, payload } = await requestJson(url, options);
-
-    if (response.status === 401) {
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-
-    if (!response.ok) {
-        throw new Error(payload?.error || payload?.stderr || `Request failed (${response.status})`);
-    }
-
-    return payload || {};
-}
 
 function statusClass(status) {
     const value = status || 'unknown';
@@ -643,25 +621,88 @@ async function restoreBackup() {
     }
 }
 
-Object.assign(window, {
-    loadStacks,
-    quickAction,
-    openStack,
-    hideStackModal,
-    showTab,
-    stackAction,
-    saveCompose,
-    saveEnv,
-    deployStack,
-    loadStackLogs,
-    showCreateStackModal,
-    hideCreateStackModal,
-    createStack,
-    confirmDeleteStack,
-    refreshBackups,
-    loadBackup,
-    restoreBackup,
-});
+function bindStacksPageActions() {
+    const refreshBtn = document.getElementById('refresh-btn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', loadStacks);
+    }
+
+    const newStackBtn = document.getElementById('new-stack-btn');
+    if (newStackBtn) {
+        newStackBtn.addEventListener('click', showCreateStackModal);
+    }
+
+    document.querySelectorAll('[data-action="hide-create-modal"]').forEach((button) => {
+        button.addEventListener('click', hideCreateStackModal);
+    });
+
+    const createStackBtn = document.getElementById('create-stack-btn');
+    if (createStackBtn) {
+        createStackBtn.addEventListener('click', createStack);
+    }
+
+    document.querySelectorAll('[data-action="hide-stack-modal"]').forEach((button) => {
+        button.addEventListener('click', hideStackModal);
+    });
+
+    document.querySelectorAll('.tab-btn').forEach((button) => {
+        button.addEventListener('click', () => {
+            const tab = button.dataset.tab;
+            if (tab) {
+                showTab(tab);
+            }
+        });
+    });
+
+    const saveComposeBtn = document.getElementById('stack-save-compose');
+    if (saveComposeBtn) {
+        saveComposeBtn.addEventListener('click', saveCompose);
+    }
+
+    const deployBtn = document.getElementById('stack-deploy');
+    if (deployBtn) {
+        deployBtn.addEventListener('click', deployStack);
+    }
+
+    const refreshBackupsBtn = document.getElementById('stack-refresh-backups');
+    if (refreshBackupsBtn) {
+        refreshBackupsBtn.addEventListener('click', refreshBackups);
+    }
+
+    const loadBackupBtn = document.getElementById('stack-load-backup');
+    if (loadBackupBtn) {
+        loadBackupBtn.addEventListener('click', loadBackup);
+    }
+
+    const restoreBackupBtn = document.getElementById('stack-restore-backup');
+    if (restoreBackupBtn) {
+        restoreBackupBtn.addEventListener('click', restoreBackup);
+    }
+
+    const saveEnvBtn = document.getElementById('stack-save-env');
+    if (saveEnvBtn) {
+        saveEnvBtn.addEventListener('click', saveEnv);
+    }
+
+    const refreshLogsBtn = document.getElementById('stack-refresh-logs');
+    if (refreshLogsBtn) {
+        refreshLogsBtn.addEventListener('click', loadStackLogs);
+    }
+
+    document.querySelectorAll('[data-stack-action]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const action = button.dataset.stackAction;
+            if (action) {
+                stackAction(action);
+            }
+        });
+    });
+
+    const deleteBtn = document.getElementById('stack-delete');
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', confirmDeleteStack);
+    }
+}
 
 (async function initStacksPage() {
     const authenticated = await ensureAuthenticated();
@@ -672,6 +713,7 @@ Object.assign(window, {
     window.logout = logoutToLogin;
 
     initEditors();
+    bindStacksPageActions();
     await loadStacks();
     window.setInterval(loadStacks, 30000);
 })();

--- a/static/js/pages/system.js
+++ b/static/js/pages/system.js
@@ -1,5 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { requestJson } from '/js/lib/http.js';
+import { formatBytes } from '/js/lib/format.js';
+import { showNotification } from '/js/lib/notify.js';
 
 const els = {
     cpuUsage: document.getElementById('cpu-usage'),
@@ -26,18 +28,9 @@ const els = {
     wifiInterface: document.getElementById('wifi-interface'),
     wifiSignal: document.getElementById('wifi-signal'),
     wifiBar: document.getElementById('wifi-bar'),
-    notificationArea: document.getElementById('notification-area'),
 };
 
 let networkSnapshot = { recv: null, sent: null, time: null };
-
-function formatBytes(bytes, decimals = 2) {
-    if (!Number.isFinite(bytes) || bytes <= 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(decimals))} ${sizes[i]}`;
-}
 
 function nowTime() {
     const date = new Date();
@@ -48,20 +41,6 @@ function colorClass(percent) {
     if (percent < 70) return 'ph-positive';
     if (percent < 85) return 'ph-warn';
     return 'ph-danger';
-}
-
-function showNotification(message, type = 'info') {
-    if (!els.notificationArea) return;
-
-    const notification = document.createElement('div');
-    notification.className = 'rounded shadow-lg px-3 py-2 mb-2 text-white opacity-95';
-    if (type === 'success') notification.classList.add('bg-green-600');
-    else if (type === 'error') notification.classList.add('bg-red-600');
-    else notification.classList.add('bg-blue-600');
-
-    notification.textContent = message;
-    els.notificationArea.appendChild(notification);
-    window.setTimeout(() => notification.remove(), 3200);
 }
 
 function renderCoreBreakdown(cores = []) {

--- a/static/js/pages/system.js
+++ b/static/js/pages/system.js
@@ -1,7 +1,16 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
+import { ensureDashboardShell } from '/js/lib/layout.js';
+import { createErrorState, createLoadingState } from '/js/lib/states.js';
 import { requestJson } from '/js/lib/http.js';
 import { formatBytes } from '/js/lib/format.js';
 import { showNotification } from '/js/lib/notify.js';
+
+ensureDashboardShell({
+    bodyClass: 'ph-system bg-gray-900 text-blue-100 font-sans min-h-screen',
+    navClass: 'bg-slate-900/90 shadow-md',
+    notificationClass: 'fixed top-4 right-4 z-50 w-72 flex flex-col items-end',
+    includeFooter: true,
+});
 
 const els = {
     cpuUsage: document.getElementById('cpu-usage'),
@@ -31,6 +40,33 @@ const els = {
 };
 
 let networkSnapshot = { recv: null, sent: null, time: null };
+let hasLoadedMetrics = false;
+
+function setSystemState(stateNode = null) {
+    const stateEl = document.getElementById('system-state');
+    const metricsGrid = document.querySelector('main .ph-grid');
+    const actions = document.getElementById('actions');
+    const piSection = document.getElementById('pi-metrics-section');
+
+    if (!stateEl) {
+        return;
+    }
+
+    if (!stateNode) {
+        stateEl.classList.add('hidden');
+        stateEl.textContent = '';
+        metricsGrid?.classList.remove('hidden');
+        actions?.classList.remove('hidden');
+        return;
+    }
+
+    stateEl.classList.remove('hidden');
+    stateEl.textContent = '';
+    stateEl.appendChild(stateNode);
+    metricsGrid?.classList.add('hidden');
+    actions?.classList.add('hidden');
+    piSection?.classList.add('hidden');
+}
 
 function nowTime() {
     const date = new Date();
@@ -169,6 +205,7 @@ async function fetchSystemMetrics() {
             throw new Error(payload?.error || `Request failed (${response.status})`);
         }
         const data = payload;
+        setSystemState(null);
 
         const cpuPercent = data.cpu_usage_percent ? Number(data.cpu_usage_percent.toFixed(1)) : 0;
         applyValue(els.cpuUsage, `${cpuPercent}%`, cpuPercent);
@@ -217,8 +254,21 @@ async function fetchSystemMetrics() {
 
         updatePiMetrics(data);
         els.lastUpdated.textContent = `Last updated: ${nowTime()}`;
+        hasLoadedMetrics = true;
     } catch (error) {
         console.error('Error fetching system metrics:', error);
+
+        if (!hasLoadedMetrics) {
+            setSystemState(createErrorState({
+                title: 'Unable to load system metrics',
+                subtitle: error.message || 'Unknown error',
+                containerClass: 'text-center py-10',
+                titleClass: 'text-red-400',
+            }));
+            showNotification('Error fetching system metrics', 'error');
+            return;
+        }
+
         [els.cpuUsage, els.memoryUsage, els.temperature, els.diskUsage, els.diskUsage2].forEach((el) => {
             el.textContent = 'Error';
             el.classList.remove('ph-positive', 'ph-warn');
@@ -257,6 +307,12 @@ async function sendSystemAction(action) {
     if (!authenticated) return;
 
     window.logout = logoutToLogin;
+
+    setSystemState(createLoadingState({
+        message: 'Loading system metrics...',
+        containerClass: 'text-center py-10',
+        messageClass: 'text-gray-400',
+    }));
 
     document.querySelectorAll('[data-action]').forEach((button) => {
         button.addEventListener('click', () => sendSystemAction(button.dataset.action));

--- a/static/js/pages/system.js
+++ b/static/js/pages/system.js
@@ -66,20 +66,44 @@ function showNotification(message, type = 'info') {
 
 function renderCoreBreakdown(cores = []) {
     if (!cores.length) {
-        els.cpuCores.innerHTML = '<div class="ph-muted">Per-core stats unavailable</div>';
+        els.cpuCores.textContent = '';
+        const empty = document.createElement('div');
+        empty.className = 'ph-muted';
+        empty.textContent = 'Per-core stats unavailable';
+        els.cpuCores.appendChild(empty);
         return;
     }
 
-    els.cpuCores.innerHTML = cores.map((core) => {
-        const pct = core.usage_percent ? core.usage_percent.toFixed(1) : '0.0';
-        return `
-            <div class="flex items-center justify-between gap-3 ph-metric-row">
-                <span class="w-16">${core.core}</span>
-                <div class="flex-1 ph-progress"><div style="width:${pct}%;background:#0ea5e9"></div></div>
-                <span class="w-12 text-right">${pct}%</span>
-            </div>
-        `;
-    }).join('');
+    els.cpuCores.textContent = '';
+
+    cores.forEach((core) => {
+        const usage = Number(core?.usage_percent);
+        const pct = Number.isFinite(usage) ? usage : 0;
+        const pctText = pct.toFixed(1);
+
+        const row = document.createElement('div');
+        row.className = 'flex items-center justify-between gap-3 ph-metric-row';
+
+        const label = document.createElement('span');
+        label.className = 'w-16';
+        label.textContent = core?.core || 'Core';
+
+        const progress = document.createElement('div');
+        progress.className = 'flex-1 ph-progress';
+        const progressFill = document.createElement('div');
+        progressFill.style.width = `${Math.max(0, Math.min(pct, 100))}%`;
+        progressFill.style.background = '#0ea5e9';
+        progress.appendChild(progressFill);
+
+        const value = document.createElement('span');
+        value.className = 'w-12 text-right';
+        value.textContent = `${pctText}%`;
+
+        row.appendChild(label);
+        row.appendChild(progress);
+        row.appendChild(value);
+        els.cpuCores.appendChild(row);
+    });
 }
 
 function applyValue(el, value, percent) {
@@ -97,25 +121,54 @@ function updatePiMetrics(data) {
     }
 
     const t = data.throttling;
+    els.throttleStatus.textContent = '';
+
     if (!t) {
-        els.throttleStatus.innerHTML = '<p class="ph-muted">N/A</p>';
+        const item = document.createElement('p');
+        item.className = 'ph-muted';
+        item.textContent = 'N/A';
+        els.throttleStatus.appendChild(item);
     } else if (t.has_issues) {
         const issues = [];
-        if (t.under_voltage_now) issues.push('<p class="ph-danger">Under-voltage detected</p>');
-        if (t.throttled_now) issues.push('<p class="ph-danger">CPU throttled</p>');
-        if (t.freq_capped_now) issues.push('<p class="ph-warn">Frequency capped</p>');
-        if (t.soft_temp_limit_now) issues.push('<p class="ph-warn">Soft temp limit</p>');
-        els.throttleStatus.innerHTML = issues.join('');
+        if (t.under_voltage_now) issues.push({ className: 'ph-danger', text: 'Under-voltage detected' });
+        if (t.throttled_now) issues.push({ className: 'ph-danger', text: 'CPU throttled' });
+        if (t.freq_capped_now) issues.push({ className: 'ph-warn', text: 'Frequency capped' });
+        if (t.soft_temp_limit_now) issues.push({ className: 'ph-warn', text: 'Soft temp limit' });
+
+        issues.forEach((issue) => {
+            const item = document.createElement('p');
+            item.className = issue.className;
+            item.textContent = issue.text;
+            els.throttleStatus.appendChild(item);
+        });
     } else {
-        els.throttleStatus.innerHTML = '<p class="ph-positive">All OK</p>';
+        const item = document.createElement('p');
+        item.className = 'ph-positive';
+        item.textContent = 'All OK';
+        els.throttleStatus.appendChild(item);
     }
 
     if (t?.has_historical_issues && !t.has_issues) {
-        els.throttleStatus.innerHTML += '<p class="ph-muted">Historical issues detected since boot</p>';
+        const historical = document.createElement('p');
+        historical.className = 'ph-muted';
+        historical.textContent = 'Historical issues detected since boot';
+        els.throttleStatus.appendChild(historical);
     }
 
-    els.cpuFreq.innerHTML = `Frequency: <span class="ph-muted">${data.cpu_freq_mhz ? `${data.cpu_freq_mhz} MHz` : '—'}</span>`;
-    els.cpuVoltage.innerHTML = `Voltage: <span class="ph-muted">${data.cpu_voltage ? `${data.cpu_voltage.toFixed(4)} V` : '—'}</span>`;
+    const cpuFreq = Number(data.cpu_freq_mhz);
+    const cpuVoltage = Number(data.cpu_voltage);
+
+    els.cpuFreq.textContent = 'Frequency: ';
+    const freqValue = document.createElement('span');
+    freqValue.className = 'ph-muted';
+    freqValue.textContent = Number.isFinite(cpuFreq) ? `${cpuFreq} MHz` : '—';
+    els.cpuFreq.appendChild(freqValue);
+
+    els.cpuVoltage.textContent = 'Voltage: ';
+    const voltageValue = document.createElement('span');
+    voltageValue.className = 'ph-muted';
+    voltageValue.textContent = Number.isFinite(cpuVoltage) ? `${cpuVoltage.toFixed(4)} V` : '—';
+    els.cpuVoltage.appendChild(voltageValue);
 
     if (!data.wifi_signal) {
         els.wifiCard.classList.add('hidden');

--- a/static/js/pages/tailscale.js
+++ b/static/js/pages/tailscale.js
@@ -1,7 +1,10 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
-import { clearElement, createErrorState, createLoadingState } from '/js/lib/states.js';
+import { createErrorState, createLoadingState } from '/js/lib/states.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { formatBytes } from '/js/lib/format.js';
+import { showNotification as showBaseNotification } from '/js/lib/notify.js';
+import { setNodeContent } from '/js/lib/dom.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -9,43 +12,6 @@ ensureDashboardShell({
 });
 
 let currentStatus = null;
-
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
-
-function escapeHtml(text) {
-    if (!text) return '';
-    return String(text)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
-}
-
-function formatBytes(bytes) {
-    if (!bytes || bytes <= 0) return '0 B';
-    const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
-}
-
-function setNodeContent(containerId, node) {
-    const container = document.getElementById(containerId);
-    if (!container) {
-        return;
-    }
-    clearElement(container);
-    container.appendChild(node);
-}
 
 function setLoadingState(isLoading, message = '') {
     const loadingState = document.getElementById('loading-state');
@@ -135,17 +101,22 @@ function showStatusSection(data) {
     if (healthSection && healthList) {
         if (health.length > 0) {
             healthSection.classList.remove('hidden');
-            healthList.innerHTML = health.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+            healthList.textContent = '';
+            health.forEach((item) => {
+                const li = document.createElement('li');
+                li.textContent = item;
+                healthList.appendChild(li);
+            });
         } else {
             healthSection.classList.add('hidden');
-            healthList.innerHTML = '';
+            healthList.textContent = '';
         }
     }
 }
 
 async function loadStatus() {
     try {
-        const response = await apiFetch('/api/tailscale/status');
+        const response = await requestApiResponse('/api/tailscale/status');
         const data = await response.json().catch(() => ({}));
 
         if (!response.ok) {
@@ -168,30 +139,16 @@ async function loadStatus() {
 }
 
 function showNotification(message, type = 'info') {
-    const area = document.getElementById('notification-area');
-    if (!area) {
-        return;
-    }
-
-    const colors = {
-        success: 'bg-green-800 border-green-600',
-        error: 'bg-red-800 border-red-600',
-        info: 'bg-blue-800 border-blue-600',
-    };
-
-    const notification = document.createElement('div');
-    notification.className = `${colors[type] || colors.info} border rounded-lg p-4 shadow-lg transition-opacity duration-500`;
-
-    const messageEl = document.createElement('p');
-    messageEl.className = 'text-white text-sm';
-    messageEl.textContent = message;
-    notification.appendChild(messageEl);
-
-    area.appendChild(notification);
-    setTimeout(() => {
-        notification.classList.add('opacity-0');
-        setTimeout(() => notification.remove(), 500);
-    }, 5000);
+    showBaseNotification(message, type, {
+        duration: 5000,
+        baseClass: 'border rounded-lg p-4 shadow-lg transition-opacity duration-500 opacity-0 text-white',
+        colorMap: {
+            success: 'bg-green-800 border-green-600',
+            error: 'bg-red-800 border-red-600',
+            info: 'bg-blue-800 border-blue-600',
+            warning: 'bg-yellow-800 border-yellow-600',
+        },
+    });
 }
 
 async function setupTailscale() {
@@ -200,7 +157,7 @@ async function setupTailscale() {
     showNotification('Installing and configuring Tailscale...', 'info');
 
     try {
-        const response = await apiFetch('/api/setup/tailscale', {
+        const response = await requestApiResponse('/api/setup/tailscale', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ auth_key: authKey }),
@@ -224,7 +181,7 @@ async function reauthenticate() {
     }
 
     try {
-        const response = await apiFetch('/api/tailscale/logout', { method: 'POST' });
+        const response = await requestApiResponse('/api/tailscale/logout', { method: 'POST' });
         const data = await response.json().catch(() => ({}));
 
         if (!response.ok) {
@@ -247,11 +204,22 @@ function refreshStatus() {
     loadStatus();
 }
 
-Object.assign(window, {
-    setupTailscale,
-    reauthenticate,
-    refreshStatus,
-});
+function bindTailscaleActions() {
+    const setupButton = document.getElementById('tailscale-setup-btn');
+    if (setupButton) {
+        setupButton.addEventListener('click', setupTailscale);
+    }
+
+    const refreshButton = document.getElementById('tailscale-refresh-btn');
+    if (refreshButton) {
+        refreshButton.addEventListener('click', refreshStatus);
+    }
+
+    const reauthButton = document.getElementById('tailscale-reauth-btn');
+    if (reauthButton) {
+        reauthButton.addEventListener('click', reauthenticate);
+    }
+}
 
 (async function initTailscalePage() {
     const authenticated = await ensureAuthenticated();
@@ -260,5 +228,6 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    bindTailscaleActions();
     await loadStatus();
 })();

--- a/static/js/pages/tailscale.js
+++ b/static/js/pages/tailscale.js
@@ -1,6 +1,7 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
 import { clearClientSession } from '/js/lib/session.js';
+import { clearElement, createErrorState, createLoadingState } from '/js/lib/states.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
@@ -37,6 +38,15 @@ function formatBytes(bytes) {
     return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
 }
 
+function setNodeContent(containerId, node) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+        return;
+    }
+    clearElement(container);
+    container.appendChild(node);
+}
+
 function setLoadingState(isLoading, message = '') {
     const loadingState = document.getElementById('loading-state');
     if (!loadingState) {
@@ -45,13 +55,11 @@ function setLoadingState(isLoading, message = '') {
 
     if (isLoading) {
         loadingState.classList.remove('hidden');
-        loadingState.innerHTML = `
-            <svg class="animate-spin h-8 w-8 mx-auto mb-4 text-purple-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
-            ${message || 'Loading Tailscale status...'}
-        `;
+        setNodeContent('loading-state', createLoadingState({
+            message: message || 'Loading Tailscale status...',
+            containerClass: 'text-center py-10',
+            messageClass: 'text-gray-400',
+        }));
     } else {
         loadingState.classList.add('hidden');
     }
@@ -63,7 +71,11 @@ function setLoadError(message) {
         return;
     }
     loadingState.classList.remove('hidden');
-    loadingState.innerHTML = `<p class="text-red-400">Failed to load Tailscale status: ${escapeHtml(message)}</p>`;
+    setNodeContent('loading-state', createErrorState({
+        title: `Failed to load Tailscale status: ${message}`,
+        containerClass: 'text-center py-10',
+        titleClass: 'text-red-400',
+    }));
 }
 
 function showSetupSection(status) {

--- a/static/js/pages/tools.js
+++ b/static/js/pages/tools.js
@@ -1,21 +1,12 @@
 import { ensureAuthenticated, logoutToLogin } from '/js/lib/auth.js';
 import { ensureDashboardShell } from '/js/lib/layout.js';
-import { clearClientSession } from '/js/lib/session.js';
+import { requestApiResponse } from '/js/lib/http.js';
+import { showNotification } from '/js/lib/notify.js';
 
 ensureDashboardShell({
     notificationClass: 'fixed top-4 right-4 z-50 w-80 flex flex-col items-end',
     includeFooter: true,
 });
-
-async function apiFetch(url, options = {}) {
-    const response = await fetch(url, options);
-    if (response.status === 401) {
-        clearClientSession();
-        window.location.href = '/login.html';
-        throw new Error('Authentication required');
-    }
-    return response;
-}
 
 function statusPill(status) {
     if (status === 'active') return 'status-healthy';
@@ -23,25 +14,9 @@ function statusPill(status) {
     return 'status-unconfigured';
 }
 
-function showNotification(message, type = 'info') {
-    const notificationArea = document.getElementById('notification-area');
-    if (!notificationArea) {
-        return;
-    }
-
-    const notification = document.createElement('div');
-    notification.className = `mb-3 p-4 rounded shadow-lg text-white max-w-sm ${
-        type === 'error' ? 'bg-red-600' :
-        type === 'success' ? 'bg-green-600' : 'bg-blue-600'
-    }`;
-    notification.textContent = message;
-    notificationArea.appendChild(notification);
-    setTimeout(() => notification.remove(), 4000);
-}
-
 async function loadCopyParty() {
     try {
-        const res = await apiFetch('/api/tools/copyparty/status');
+        const res = await requestApiResponse('/api/tools/copyparty/status');
         const data = await res.json().catch(() => ({}));
         if (!res.ok) {
             throw new Error(data.error || 'Failed to load');
@@ -79,7 +54,7 @@ async function loadCopyParty() {
 
 async function installCopyParty() {
     try {
-        const res = await apiFetch('/api/tools/copyparty/install', {
+        const res = await requestApiResponse('/api/tools/copyparty/install', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
         });
@@ -103,7 +78,7 @@ async function saveCopyPartyConfig() {
     };
 
     try {
-        const res = await apiFetch('/api/tools/copyparty/config', {
+        const res = await requestApiResponse('/api/tools/copyparty/config', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
@@ -120,11 +95,6 @@ async function saveCopyPartyConfig() {
     }
 }
 
-Object.assign(window, {
-    installCopyParty,
-    saveCopyPartyConfig,
-});
-
 (async function initToolsPage() {
     const authenticated = await ensureAuthenticated();
     if (!authenticated) {
@@ -132,5 +102,7 @@ Object.assign(window, {
     }
 
     window.logout = logoutToLogin;
+    document.getElementById('copyparty-install-btn')?.addEventListener('click', installCopyParty);
+    document.getElementById('copyparty-save-config')?.addEventListener('click', saveCopyPartyConfig);
     await loadCopyParty();
 })();

--- a/static/mounts.html
+++ b/static/mounts.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/mounts.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/mounts.html
+++ b/static/mounts.html
@@ -39,7 +39,7 @@
                     <h3 class="text-lg font-semibold">Media Paths</h3>
                     <p class="text-gray-400 text-sm">Default paths used by app templates</p>
                 </div>
-                <button onclick="saveMediaPaths()" class="coraline-button text-blue-100 py-2 px-4 rounded text-sm">Save Paths</button>
+                <button id="save-media-paths" type="button" class="coraline-button text-blue-100 py-2 px-4 rounded text-sm">Save Paths</button>
             </div>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
                 <div>
@@ -60,7 +60,7 @@
                 </div>
             </div>
             <div class="mt-4 pt-4 border-t border-purple-900/40">
-                <button onclick="previewStartupService()" class="text-sm text-purple-400 hover:text-purple-300">
+                <button id="preview-startup-service" type="button" class="text-sm text-purple-400 hover:text-purple-300">
                     Regenerate Startup Service...
                 </button>
             </div>
@@ -77,24 +77,24 @@
         <div class="bg-gray-900 w-full max-w-lg rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh]">
             <div class="flex justify-between items-center p-4 border-b border-purple-800 flex-shrink-0">
                 <h3 id="mount-modal-title" class="text-xl font-semibold">Add Mount</h3>
-                <button onclick="closeMountModal()" class="text-gray-400 hover:text-white text-2xl">&times;</button>
+                <button type="button" data-action="close-mount-modal" class="text-gray-400 hover:text-white text-2xl">&times;</button>
             </div>
             <div class="p-4 overflow-y-auto flex-1 min-h-0" id="mount-modal-form">
                 <!-- Form fields populated by JS -->
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-end gap-3 flex-shrink-0">
-                <button onclick="closeMountModal()" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
-                <button id="mount-modal-submit" onclick="submitMountForm()" class="coraline-button px-4 py-2 rounded text-white">Save</button>
+                <button type="button" data-action="close-mount-modal" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
+                <button id="mount-modal-submit" type="button" data-action="submit-mount-form" class="coraline-button px-4 py-2 rounded text-white">Save</button>
             </div>
         </div>
     </div>
 
     <!-- Diff Preview Modal -->
-    <div id="diff-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4 overflow-y-auto" onclick="if(event.target === this) closeDiffModal()">
-        <div class="bg-gray-800 w-full max-w-4xl rounded-lg shadow-xl border border-purple-900 flex flex-col my-auto" style="max-height: calc(100vh - 2rem);" onclick="event.stopPropagation()">
+    <div id="diff-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4 overflow-y-auto" data-overlay-close="diff-modal">
+        <div class="bg-gray-800 w-full max-w-4xl rounded-lg shadow-xl border border-purple-900 flex flex-col my-auto" style="max-height: calc(100vh - 2rem);" data-modal-panel>
             <div class="flex justify-between items-center p-4 border-b border-purple-800 flex-shrink-0">
                 <h3 class="text-xl font-semibold">Startup Service Changes</h3>
-                <button onclick="closeDiffModal()" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
+                <button type="button" data-action="close-diff-modal" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
             </div>
             <div class="p-4 overflow-y-auto flex-1" style="min-height: 0;">
                 <div id="diff-content" class="space-y-6">
@@ -102,8 +102,8 @@
                 </div>
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-end gap-3 flex-shrink-0">
-                <button onclick="closeDiffModal()" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
-                <button onclick="applyStartupService()" class="coraline-button px-4 py-2 rounded text-white">Apply Changes</button>
+                <button type="button" data-action="close-diff-modal" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
+                <button type="button" data-action="apply-startup-service" class="coraline-button px-4 py-2 rounded text-white">Apply Changes</button>
             </div>
         </div>
     </div>

--- a/static/network.html
+++ b/static/network.html
@@ -31,7 +31,7 @@
                 <h2 class="text-2xl font-semibold">Host Network</h2>
                 <p class="text-sm text-gray-400 mt-1">Detailed network information for this host.</p>
             </div>
-            <button onclick="refreshNetworkInfo()" class="px-4 py-2 text-sm border border-purple-700 text-purple-300 rounded hover:bg-purple-900">
+            <button id="refresh-network-info" type="button" class="px-4 py-2 text-sm border border-purple-700 text-purple-300 rounded hover:bg-purple-900">
                 Refresh
             </button>
         </div>

--- a/static/network.html
+++ b/static/network.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/network.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/plugins.html
+++ b/static/plugins.html
@@ -38,7 +38,7 @@
 
         <div class="mb-6 flex items-center justify-between">
             <p class="text-sm text-gray-400">Install third-party plugins from GitHub or pip.</p>
-            <button onclick="openInstallModal()" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded">+ Add Plugin</button>
+            <button id="plugin-open-install" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded">+ Add Plugin</button>
         </div>
 
         <div id="plugins-list" class="space-y-4">
@@ -50,12 +50,12 @@
         <div class="bg-gray-800 w-full max-w-lg rounded-lg shadow-xl border border-purple-900">
             <div class="p-4 border-b border-purple-800 flex justify-between items-center">
                 <h3 class="text-xl font-semibold">Install Plugin</h3>
-                <button onclick="closeInstallModal()" class="text-gray-400 hover:text-white">&times;</button>
+                <button id="plugin-close-install-top" class="text-gray-400 hover:text-white">&times;</button>
             </div>
             <form id="install-form" class="p-4 space-y-4">
                 <div>
                     <label class="block text-sm text-gray-400 mb-1">Source Type</label>
-                    <select name="type" onchange="toggleInstallType(this.value)"
+                    <select id="plugin-install-type" name="type"
                             class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white">
                         <option value="github">GitHub Repo</option>
                         <option value="pip">pip Package</option>
@@ -88,8 +88,8 @@
                 </div>
             </form>
             <div class="p-4 border-t border-purple-800 flex justify-end gap-3">
-                <button onclick="closeInstallModal()" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
-                <button onclick="submitInstall()" class="coraline-button px-4 py-2 rounded">Install</button>
+                <button id="plugin-close-install-bottom" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
+                <button id="plugin-submit-install" class="coraline-button px-4 py-2 rounded">Install</button>
             </div>
         </div>
     </div>

--- a/static/plugins.html
+++ b/static/plugins.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/plugins.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/pools.html
+++ b/static/pools.html
@@ -34,7 +34,7 @@
             </div>
             <div id="pool-filter-wrap" class="hidden">
                 <label class="block text-xs text-gray-400 mb-1">Plugin</label>
-                <select id="pool-filter" onchange="setPoolFilter(this.value)"
+                <select id="pool-filter"
                         class="bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-white">
                     <option value="all">All</option>
                 </select>
@@ -47,11 +47,11 @@
     </main>
 
     <!-- Command Output Modal -->
-    <div id="output-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" onclick="if(event.target === this) closeOutputModal()">
-        <div class="bg-gray-900 w-full max-w-3xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh]" onclick="event.stopPropagation()">
+    <div id="output-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" data-overlay-close="output-modal">
+        <div class="bg-gray-900 w-full max-w-3xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh]" data-modal-panel>
             <div class="flex justify-between items-center p-4 border-b border-purple-800 flex-shrink-0">
                 <h3 id="output-modal-title" class="text-xl font-semibold">Command Output</h3>
-                <button onclick="closeOutputModal()" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
+                <button type="button" data-action="close-output-modal" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
             </div>
             <div class="p-4 overflow-y-auto flex-1 min-h-0 bg-gray-950">
                 <div id="snapraid-progress" class="hidden bg-gray-900 border border-purple-900/40 rounded mb-3 p-3 text-xs text-gray-300">
@@ -68,35 +68,35 @@
                 <div id="output-content" class="output-panel text-gray-300"></div>
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-end flex-shrink-0">
-                <button onclick="closeOutputModal()" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Close</button>
+                <button type="button" data-action="close-output-modal" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Close</button>
             </div>
         </div>
     </div>
 
     <!-- Command Params Modal -->
-    <div id="command-param-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" onclick="if(event.target === this) closeCommandParamModal()">
-        <div class="bg-gray-900 w-full max-w-md rounded-lg shadow-xl border border-purple-900 flex flex-col" onclick="event.stopPropagation()">
+    <div id="command-param-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" data-overlay-close="command-param-modal">
+        <div class="bg-gray-900 w-full max-w-md rounded-lg shadow-xl border border-purple-900 flex flex-col" data-modal-panel>
             <div class="flex justify-between items-center p-4 border-b border-purple-800">
                 <h3 id="command-param-title" class="text-lg font-semibold">Select Pool</h3>
-                <button onclick="closeCommandParamModal()" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
+                <button type="button" data-action="close-command-param-modal" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
             </div>
             <div class="p-4">
                 <label class="block text-sm text-gray-300 mb-2">Pool</label>
                 <select id="command-pool-select" class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white text-sm"></select>
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-end gap-2">
-                <button onclick="closeCommandParamModal()" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Cancel</button>
-                <button onclick="confirmCommandParams()" class="px-4 py-2 coraline-button text-white rounded">Run</button>
+                <button type="button" data-action="close-command-param-modal" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Cancel</button>
+                <button type="button" data-action="confirm-command-params" class="px-4 py-2 coraline-button text-white rounded">Run</button>
             </div>
         </div>
     </div>
 
     <!-- SnapRAID Sync Confirm Modal -->
-    <div id="snapraid-sync-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" onclick="if(event.target === this) closeSnapraidSyncModal()">
-        <div class="bg-gray-900 w-full max-w-lg rounded-lg shadow-xl border border-purple-900 flex flex-col" onclick="event.stopPropagation()">
+    <div id="snapraid-sync-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" data-overlay-close="snapraid-sync-modal">
+        <div class="bg-gray-900 w-full max-w-lg rounded-lg shadow-xl border border-purple-900 flex flex-col" data-modal-panel>
             <div class="flex justify-between items-center p-4 border-b border-purple-800">
                 <h3 class="text-lg font-semibold">Confirm SnapRAID Sync</h3>
-                <button onclick="closeSnapraidSyncModal()" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
+                <button type="button" data-action="close-snapraid-sync-modal" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
             </div>
             <div class="p-4 text-sm text-gray-300 space-y-3">
                 <p>Review the diff summary before syncing.</p>
@@ -104,27 +104,27 @@
                 <div id="snapraid-sync-warning" class="hidden text-yellow-300 text-xs"></div>
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-end gap-2">
-                <button onclick="closeSnapraidSyncModal()" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Cancel</button>
-                <button id="snapraid-sync-confirm" onclick="confirmSnapraidSync()" class="px-4 py-2 coraline-button text-white rounded">Sync Now</button>
+                <button type="button" data-action="close-snapraid-sync-modal" class="px-4 py-2 bg-gray-700 text-white rounded hover:bg-gray-600">Cancel</button>
+                <button id="snapraid-sync-confirm" type="button" data-action="confirm-snapraid-sync" class="px-4 py-2 coraline-button text-white rounded">Sync Now</button>
             </div>
         </div>
     </div>
 
     <!-- Configure Modal -->
-    <div id="config-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" onclick="if(event.target === this) closeConfigModal()">
-        <div class="bg-gray-900 w-full max-w-2xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh] overflow-hidden" onclick="event.stopPropagation()">
+    <div id="config-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" data-overlay-close="config-modal">
+        <div class="bg-gray-900 w-full max-w-2xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[90vh] overflow-hidden" data-modal-panel>
             <div class="flex justify-between items-center p-4 border-b border-purple-800 flex-shrink-0">
                 <h3 id="config-modal-title" class="text-xl font-semibold">Configure Plugin</h3>
-                <button onclick="closeConfigModal()" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
+                <button type="button" data-action="close-config-modal" class="text-gray-400 hover:text-white text-2xl font-bold leading-none">&times;</button>
             </div>
             <div class="p-4 overflow-y-auto flex-1 min-h-0" id="config-modal-form">
                 <!-- Form fields populated by JS -->
             </div>
             <div class="p-4 border-t border-purple-800 flex justify-between flex-shrink-0">
-                <button onclick="applyConfig()" class="coraline-button px-4 py-2 rounded text-white">Apply to System</button>
+                <button type="button" data-action="apply-config" class="coraline-button px-4 py-2 rounded text-white">Apply to System</button>
                 <div class="flex gap-2">
-                    <button onclick="closeConfigModal()" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
-                    <button onclick="saveConfig()" class="coraline-button px-4 py-2 rounded text-white">Save</button>
+                    <button type="button" data-action="close-config-modal" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
+                    <button type="button" data-action="save-config" class="coraline-button px-4 py-2 rounded text-white">Save</button>
                 </div>
             </div>
         </div>

--- a/static/pools.html
+++ b/static/pools.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/pools.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/settings.html
+++ b/static/settings.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/settings.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/shares.html
+++ b/static/shares.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/shares.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/shares.html
+++ b/static/shares.html
@@ -50,13 +50,13 @@
     </main>
 
     <!-- Add/Edit Share Modal -->
-    <div id="share-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" onclick="if(event.target === this) closeShareModal()">
-        <div class="bg-gray-800 w-full max-w-lg rounded-lg shadow-xl border border-purple-900" onclick="event.stopPropagation()">
+    <div id="share-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center p-4" data-overlay-close="share-modal">
+        <div class="bg-gray-800 w-full max-w-lg rounded-lg shadow-xl border border-purple-900" data-modal-panel>
             <div class="flex justify-between items-center p-4 border-b border-purple-800">
                 <h3 id="modal-title" class="text-xl font-semibold">Add Share</h3>
-                <button onclick="closeShareModal()" class="text-gray-400 hover:text-white text-2xl">&times;</button>
+                <button type="button" data-action="close-share-modal" class="text-gray-400 hover:text-white text-2xl">&times;</button>
             </div>
-            <form id="share-form" class="p-4 space-y-4" onsubmit="saveShare(event)">
+            <form id="share-form" class="p-4 space-y-4">
                 <input type="hidden" id="share-plugin-id">
                 <input type="hidden" id="share-edit-mode">
                 <input type="hidden" id="share-original-name">
@@ -124,7 +124,7 @@
                 </div>
 
                 <div class="flex justify-end gap-3 pt-4 border-t border-gray-700">
-                    <button type="button" onclick="closeShareModal()" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
+                    <button type="button" data-action="close-share-modal" class="px-4 py-2 text-gray-400 hover:text-white">Cancel</button>
                     <button type="submit" class="coraline-button px-6 py-2 rounded text-white">Save Share</button>
                 </div>
             </form>
@@ -136,13 +136,13 @@
         <div class="bg-gray-900 w-full max-w-2xl rounded-lg shadow-xl border border-purple-900 flex flex-col max-h-[80vh]">
             <div class="flex justify-between items-center p-4 border-b border-purple-800">
                 <h3 id="output-modal-title" class="text-xl font-semibold">Command Output</h3>
-                <button onclick="closeOutputModal()" class="text-gray-400 hover:text-white text-2xl">&times;</button>
+                <button type="button" data-action="close-output-modal" class="text-gray-400 hover:text-white text-2xl">&times;</button>
             </div>
             <div class="p-4 overflow-y-auto flex-1 bg-gray-950">
                 <pre id="output-content" class="text-sm font-mono text-green-400 whitespace-pre-wrap"></pre>
             </div>
             <div class="p-4 border-t border-purple-800">
-                <button onclick="closeOutputModal()" class="coraline-button px-4 py-2 rounded">Close</button>
+                <button type="button" data-action="close-output-modal" class="coraline-button px-4 py-2 rounded">Close</button>
             </div>
         </div>
     </div>

--- a/static/stacks.html
+++ b/static/stacks.html
@@ -37,13 +37,13 @@
         <div class="flex justify-between items-center mb-6">
             <h2 class="text-2xl font-semibold">Docker Stacks</h2>
             <div class="flex space-x-2">
-                <button id="refresh-btn" onclick="loadStacks()" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded flex items-center">
+                <button id="refresh-btn" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded flex items-center">
                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                     </svg>
                     Refresh
                 </button>
-                <button onclick="showCreateStackModal()" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded flex items-center">
+                <button id="new-stack-btn" class="coraline-button text-blue-100 font-bold py-2 px-4 rounded flex items-center">
                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
                     </svg>
@@ -74,12 +74,12 @@
 
     <!-- Create Stack Modal -->
     <div id="create-modal" class="fixed inset-0 z-50 hidden">
-        <div class="modal-backdrop absolute inset-0" onclick="hideCreateStackModal()"></div>
+        <div class="modal-backdrop absolute inset-0" data-action="hide-create-modal"></div>
         <div class="absolute inset-0 flex items-center justify-center p-4">
             <div class="bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden relative">
                 <div class="p-4 border-b border-gray-700 flex justify-between items-center">
                     <h3 class="text-xl font-semibold">Create New Stack</h3>
-                    <button onclick="hideCreateStackModal()" class="text-gray-400 hover:text-white">
+                    <button data-action="hide-create-modal" class="text-gray-400 hover:text-white">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
@@ -109,8 +109,8 @@
                     </div>
                 </div>
                 <div class="p-4 border-t border-gray-700 flex justify-end space-x-2">
-                    <button onclick="hideCreateStackModal()" class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500">Cancel</button>
-                    <button onclick="createStack()" class="coraline-button px-4 py-2 text-white rounded">Create Stack</button>
+                    <button data-action="hide-create-modal" class="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500">Cancel</button>
+                    <button id="create-stack-btn" class="coraline-button px-4 py-2 text-white rounded">Create Stack</button>
                 </div>
             </div>
         </div>
@@ -118,7 +118,7 @@
 
     <!-- Stack Detail/Edit Modal -->
     <div id="stack-modal" class="fixed inset-0 z-50 hidden">
-        <div class="modal-backdrop absolute inset-0" onclick="hideStackModal()"></div>
+        <div class="modal-backdrop absolute inset-0" data-action="hide-stack-modal"></div>
         <div class="absolute inset-0 flex items-center justify-center p-4">
             <div class="bg-gray-800 rounded-lg shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden relative">
                 <div class="p-4 border-b border-gray-700 flex justify-between items-center">
@@ -126,7 +126,7 @@
                         <span id="modal-stack-name">Stack</span>
                         <span id="modal-stack-status" class="ml-2 px-2 py-1 text-xs rounded"></span>
                     </h3>
-                    <button onclick="hideStackModal()" class="text-gray-400 hover:text-white">
+                    <button data-action="hide-stack-modal" class="text-gray-400 hover:text-white">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
@@ -136,10 +136,10 @@
                 <!-- Tabs -->
                 <div class="border-b border-gray-700">
                     <nav class="flex space-x-4 px-4">
-                        <button onclick="showTab('compose')" class="tab-btn py-2 px-3 border-b-2 border-purple-500 text-purple-400" data-tab="compose">Compose</button>
-                        <button onclick="showTab('env')" class="tab-btn py-2 px-3 border-b-2 border-transparent text-gray-400 hover:text-white" data-tab="env">Environment</button>
-                        <button onclick="showTab('logs')" class="tab-btn py-2 px-3 border-b-2 border-transparent text-gray-400 hover:text-white" data-tab="logs">Logs</button>
-                        <button onclick="showTab('terminal')" class="tab-btn py-2 px-3 border-b-2 border-transparent text-gray-400 hover:text-white" data-tab="terminal">Terminal</button>
+                        <button class="tab-btn py-2 px-3 border-b-2 border-purple-500 text-purple-400" data-tab="compose">Compose</button>
+                        <button class="tab-btn py-2 px-3 border-b-2 border-transparent text-gray-400 hover:text-white" data-tab="env">Environment</button>
+                        <button class="tab-btn py-2 px-3 border-b-2 border-transparent text-gray-400 hover:text-white" data-tab="logs">Logs</button>
+                        <button class="tab-btn py-2 px-3 border-b-2 border-transparent text-gray-400 hover:text-white" data-tab="terminal">Terminal</button>
                     </nav>
                 </div>
 
@@ -151,20 +151,20 @@
                         </div>
                         <textarea id="edit-compose" class="compose-editor w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white focus:outline-none focus:border-purple-500" rows="16"></textarea>
                         <div class="mt-2 flex justify-end space-x-2">
-                            <button onclick="saveCompose()" class="coraline-button px-4 py-2 text-white rounded">Save</button>
-                            <button onclick="deployStack()" class="coraline-button px-4 py-2 text-white rounded bg-green-700 border-green-600">Save & Deploy</button>
+                            <button id="stack-save-compose" class="coraline-button px-4 py-2 text-white rounded">Save</button>
+                            <button id="stack-deploy" class="coraline-button px-4 py-2 text-white rounded bg-green-700 border-green-600">Save & Deploy</button>
                         </div>
                         <div class="mt-4 border-t border-gray-700 pt-4">
                             <div class="flex items-center justify-between mb-2">
                                 <span class="text-sm text-gray-300">Backups</span>
-                                <button onclick="refreshBackups()" class="text-sm text-blue-300 hover:text-blue-200">Refresh</button>
+                                <button id="stack-refresh-backups" class="text-sm text-blue-300 hover:text-blue-200">Refresh</button>
                             </div>
                             <div class="flex flex-col md:flex-row gap-2">
                                 <select id="backup-select" class="bg-gray-700 border border-gray-600 rounded px-2 py-1 text-sm flex-1">
                                     <option value="">No backups available</option>
                                 </select>
-                                <button onclick="loadBackup()" class="coraline-button px-3 py-1 text-sm rounded">Load</button>
-                                <button onclick="restoreBackup()" class="px-3 py-1 text-sm rounded bg-red-700 hover:bg-red-600 text-white">Restore</button>
+                                <button id="stack-load-backup" class="coraline-button px-3 py-1 text-sm rounded">Load</button>
+                                <button id="stack-restore-backup" class="px-3 py-1 text-sm rounded bg-red-700 hover:bg-red-600 text-white">Restore</button>
                             </div>
                             <p class="text-xs text-gray-400 mt-2">Load inserts a backup into the editor. Restore overwrites the stack compose file.</p>
                         </div>
@@ -174,7 +174,7 @@
                     <div id="tab-env" class="tab-content hidden">
                         <textarea id="edit-env" class="compose-editor w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 text-white focus:outline-none focus:border-purple-500" rows="12" placeholder="# No .env file exists yet"></textarea>
                         <div class="mt-2 flex justify-end">
-                            <button onclick="saveEnv()" class="coraline-button px-4 py-2 text-white rounded">Save .env</button>
+                            <button id="stack-save-env" class="coraline-button px-4 py-2 text-white rounded">Save .env</button>
                         </div>
                     </div>
 
@@ -184,7 +184,7 @@
                             <select id="log-service" class="bg-gray-700 border border-gray-600 rounded px-2 py-1 text-sm">
                                 <option value="">All Services</option>
                             </select>
-                            <button onclick="loadStackLogs()" class="coraline-button px-3 py-1 text-sm rounded">Refresh Logs</button>
+                            <button id="stack-refresh-logs" class="coraline-button px-3 py-1 text-sm rounded">Refresh Logs</button>
                         </div>
                         <div id="logs-output" class="terminal-output h-80 p-3 rounded border border-gray-700">
                             Click "Refresh Logs" to load logs...
@@ -202,20 +202,20 @@
                 <!-- Action buttons -->
                 <div class="p-4 border-t border-gray-700 flex justify-between">
                     <div class="space-x-2">
-                        <button onclick="stackAction('up')" class="coraline-button px-3 py-2 text-sm rounded border-green-600">
+                        <button data-stack-action="up" class="coraline-button px-3 py-2 text-sm rounded border-green-600">
                             <span class="mr-1">&#9654;</span> Start
                         </button>
-                        <button onclick="stackAction('down')" class="coraline-button px-3 py-2 text-sm rounded border-red-600">
+                        <button data-stack-action="down" class="coraline-button px-3 py-2 text-sm rounded border-red-600">
                             <span class="mr-1">&#9632;</span> Stop
                         </button>
-                        <button onclick="stackAction('restart')" class="coraline-button px-3 py-2 text-sm rounded border-yellow-600">
+                        <button data-stack-action="restart" class="coraline-button px-3 py-2 text-sm rounded border-yellow-600">
                             <span class="mr-1">&#8635;</span> Restart
                         </button>
-                        <button onclick="stackAction('pull')" class="coraline-button px-3 py-2 text-sm rounded border-blue-600">
+                        <button data-stack-action="pull" class="coraline-button px-3 py-2 text-sm rounded border-blue-600">
                             <span class="mr-1">&#8595;</span> Pull
                         </button>
                     </div>
-                    <button onclick="confirmDeleteStack()" class="px-3 py-2 bg-red-700 text-white rounded hover:bg-red-600 text-sm">
+                    <button id="stack-delete" class="px-3 py-2 bg-red-700 text-white rounded hover:bg-red-600 text-sm">
                         Delete Stack
                     </button>
                 </div>

--- a/static/stacks.html
+++ b/static/stacks.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="/css/stacks.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.css">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.js"></script>

--- a/static/system.html
+++ b/static/system.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/system.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/system.html
+++ b/static/system.html
@@ -18,13 +18,15 @@
     <div id="notification-area" class="fixed top-4 right-4 z-50 w-72 flex flex-col items-end"></div>
 
     <main class="ph-system-shell">
-        <header class="ph-system-header">
+        <div class="ph-system-header">
             <div>
                 <p class="ph-system-kicker">Host Telemetry</p>
                 <h2 class="ph-system-title">System Metrics</h2>
             </div>
             <span id="last-updated" class="ph-system-updated">Last updated: Never</span>
-        </header>
+        </div>
+
+        <section id="system-state" class="hidden"></section>
 
         <section class="ph-grid">
             <article class="ph-card">

--- a/static/tailscale.html
+++ b/static/tailscale.html
@@ -63,7 +63,7 @@
                         Leave blank for interactive login via browser. Get an auth key from
                         <a href="https://login.tailscale.com/admin/settings/keys" target="_blank" class="text-purple-400 hover:underline">Tailscale Admin Console</a>.
                     </p>
-                    <button onclick="setupTailscale()" class="coraline-button text-blue-100 py-2 px-6 rounded">
+                    <button id="tailscale-setup-btn" class="coraline-button text-blue-100 py-2 px-6 rounded">
                         Install & Connect
                     </button>
                 </div>
@@ -83,10 +83,10 @@
                         </div>
                     </div>
                     <div class="flex gap-2">
-                        <button onclick="refreshStatus()" class="px-4 py-2 text-sm border border-purple-700 text-purple-300 rounded hover:bg-purple-900">
+                        <button id="tailscale-refresh-btn" class="px-4 py-2 text-sm border border-purple-700 text-purple-300 rounded hover:bg-purple-900">
                             Refresh
                         </button>
-                        <button onclick="reauthenticate()" class="px-4 py-2 text-sm border border-yellow-700 text-yellow-300 rounded hover:bg-yellow-900/30">
+                        <button id="tailscale-reauth-btn" class="px-4 py-2 text-sm border border-yellow-700 text-yellow-300 rounded hover:bg-yellow-900/30">
                             Re-authenticate
                         </button>
                     </div>

--- a/static/tailscale.html
+++ b/static/tailscale.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/tailscale.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/static/tools.html
+++ b/static/tools.html
@@ -56,11 +56,11 @@
                     </div>
 
                     <div class="flex flex-wrap items-center gap-3">
-                        <button id="copyparty-install-btn" onclick="installCopyParty()"
+                        <button id="copyparty-install-btn" type="button"
                                 class="coraline-button text-blue-100 font-bold py-2 px-4 rounded">
                             Install & Enable
                         </button>
-                        <button onclick="saveCopyPartyConfig()"
+                        <button id="copyparty-save-config" type="button"
                                 class="px-4 py-2 rounded bg-purple-700 hover:bg-purple-600 text-sm font-semibold">
                             Save & Restart
                         </button>

--- a/static/tools.html
+++ b/static/tools.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/css/foundation.css">
     <link rel="stylesheet" href="/css/tools.css">
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <script src="/js/api.js"></script>
     <script src="/js/theme.js"></script>
     <script src="/js/nav.js"></script>
 </head>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -99,6 +99,42 @@ class TestAuthentication:
         response = client.get('/api/auth/check')
         assert response.status_code == 401
 
+    def test_logout_clears_session(self, authenticated_client):
+        """Test logout clears authenticated session state."""
+        with authenticated_client.session_transaction() as sess:
+            assert sess.get('authenticated') is True
+            assert sess.get('username') == 'testuser'
+
+        response = authenticated_client.post('/api/logout')
+        assert response.status_code == 200
+
+        with authenticated_client.session_transaction() as sess:
+            assert sess.get('authenticated') is None
+            assert sess.get('username') is None
+
+    def test_auth_check_authenticated_without_username(self, client):
+        """Test auth check falls back to unknown username."""
+        with client.session_transaction() as sess:
+            sess['authenticated'] = True
+            sess.pop('username', None)
+
+        response = client.get('/api/auth/check')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['authenticated'] is True
+        assert data['username'] == 'unknown'
+
+    def test_auth_check_stale_session_is_unauthenticated(self, client):
+        """Test stale session data without auth flag is treated as unauthenticated."""
+        with client.session_transaction() as sess:
+            sess['username'] = 'stale-user'
+            sess.pop('authenticated', None)
+
+        response = client.get('/api/auth/check')
+        assert response.status_code == 401
+        data = json.loads(response.data)
+        assert data['authenticated'] is False
+
 
 class TestProtectedEndpoints:
     """Test that protected endpoints require authentication."""
@@ -142,6 +178,34 @@ class TestProtectedEndpoints:
         """Test that /api/network-test requires authentication."""
         response = client.post('/api/network-test')
         assert response.status_code == 401
+
+    def test_shutdown_with_auth_calls_system_action(self, authenticated_client, monkeypatch):
+        """Test authenticated shutdown delegates to system_action."""
+        monkeypatch.setattr('app.system_action', lambda action: {'status': f'{action}-ok'})
+        response = authenticated_client.post('/api/shutdown')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['status'] == 'shutdown-ok'
+
+    def test_reboot_with_auth_calls_system_action(self, authenticated_client, monkeypatch):
+        """Test authenticated reboot delegates to system_action."""
+        monkeypatch.setattr('app.system_action', lambda action: {'status': f'{action}-ok'})
+        response = authenticated_client.post('/api/reboot')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['status'] == 'reboot-ok'
+
+    def test_network_test_with_auth_calls_runner(self, authenticated_client, monkeypatch):
+        """Test authenticated network test delegates to run_network_test."""
+        monkeypatch.setattr(
+            'app.run_network_test',
+            lambda: {'ping_success': True, 'probe_method': 'socket'},
+        )
+        response = authenticated_client.post('/api/network-test')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['ping_success'] is True
+        assert data['probe_method'] == 'socket'
 
 
 class TestPublicEndpoints:

--- a/tests/test_app_helpers.py
+++ b/tests/test_app_helpers.py
@@ -26,6 +26,7 @@ from app import (
     calculate_container_memory_stats,
     calculate_container_network_stats,
     exec_in_container,
+    system_action,
 )
 
 
@@ -214,6 +215,22 @@ class TestHelpers:
         assert exit_code == 0
         assert "ok" in output
         assert "err" in output
+
+    def test_system_action_shutdown(self):
+        with patch("app.subprocess.Popen") as mock_popen:
+            result = system_action("shutdown")
+        mock_popen.assert_called_once_with(["sudo", "shutdown", "-h", "now"])
+        assert result["status"] == "Shutdown initiated"
+
+    def test_system_action_reboot(self):
+        with patch("app.subprocess.Popen") as mock_popen:
+            result = system_action("reboot")
+        mock_popen.assert_called_once_with(["sudo", "reboot"])
+        assert result["status"] == "Reboot initiated"
+
+    def test_system_action_invalid(self):
+        result = system_action("invalid")
+        assert result["error"] == "Invalid system action"
 
 
 class TestNetworkDiagnostics:

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -226,6 +226,27 @@ class TestContainerNetworkTest:
         data = json.loads(response.data)
         assert 'error' in data or 'container_name' in data
 
+    def test_container_network_test_docker_unavailable(self, authenticated_client, monkeypatch):
+        """Test container network endpoint returns 503 when Docker is unavailable."""
+        monkeypatch.setattr('app.docker_available', False)
+        response = authenticated_client.post('/api/containers/test-container/network-test')
+        assert response.status_code == 503
+        data = json.loads(response.data)
+        assert data['error'] == 'Docker is not available'
+
+    def test_container_network_test_with_auth_calls_runner(self, authenticated_client, monkeypatch):
+        """Test container network endpoint delegates to run_container_network_test when available."""
+        monkeypatch.setattr('app.docker_available', True)
+        monkeypatch.setattr(
+            'app.run_container_network_test',
+            lambda container_id: {'container_name': container_id, 'ping_success': True},
+        )
+        response = authenticated_client.post('/api/containers/test-container/network-test')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['container_name'] == 'test-container'
+        assert data['ping_success'] is True
+
 
 class TestHostNetworkTest:
     """Test host-level network test functionality."""

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -766,5 +766,150 @@ class TestStackEnvFile:
             stack_manager.STACKS_PATH = original_path
 
 
+class TestStackAdditionalRoutes:
+    """Test additional stack API routes with focused coverage."""
+
+    def test_scan_stacks(self, authenticated_client, temp_stacks_dir):
+        import stack_manager
+        original_path = stack_manager.STACKS_PATH
+        stack_manager.STACKS_PATH = temp_stacks_dir
+
+        stack_dir = os.path.join(temp_stacks_dir, "alpha")
+        os.makedirs(stack_dir, exist_ok=True)
+        with open(os.path.join(stack_dir, "compose.yaml"), "w") as f:
+            f.write("services: {}\n")
+
+        try:
+            response = authenticated_client.post("/api/stacks/scan")
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data["count"] == 1
+            assert data["stacks"][0]["name"] == "alpha"
+        finally:
+            stack_manager.STACKS_PATH = original_path
+
+    def test_get_compose(self, authenticated_client, temp_stacks_dir):
+        import stack_manager
+        original_path = stack_manager.STACKS_PATH
+        stack_manager.STACKS_PATH = temp_stacks_dir
+
+        stack_dir = os.path.join(temp_stacks_dir, "alpha")
+        os.makedirs(stack_dir, exist_ok=True)
+        compose_content = "services:\n  web:\n    image: nginx\n"
+        with open(os.path.join(stack_dir, "compose.yaml"), "w") as f:
+            f.write(compose_content)
+
+        try:
+            response = authenticated_client.get("/api/stacks/alpha/compose")
+            assert response.status_code == 200
+            data = response.get_json()
+            assert data["filename"] == "compose.yaml"
+            assert data["content"] == compose_content
+        finally:
+            stack_manager.STACKS_PATH = original_path
+
+    def test_stack_status_endpoint(self, authenticated_client, monkeypatch):
+        monkeypatch.setattr(
+            "stack_manager.get_stack_status",
+            lambda _name: ({"status": "running", "container_count": 2, "running_count": 2}, None),
+        )
+
+        response = authenticated_client.get("/api/stacks/alpha/status")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "running"
+        assert data["container_count"] == 2
+
+    def test_stack_restart_and_pull(self, authenticated_client, monkeypatch):
+        monkeypatch.setattr(
+            "stack_manager.run_compose_command",
+            lambda _name, _command: ({"success": True, "returncode": 0}, None),
+        )
+
+        restart_response = authenticated_client.post("/api/stacks/alpha/restart")
+        assert restart_response.status_code == 200
+        assert restart_response.get_json()["success"] is True
+
+        pull_response = authenticated_client.post("/api/stacks/alpha/pull")
+        assert pull_response.status_code == 200
+        assert pull_response.get_json()["success"] is True
+
+    def test_stack_logs(self, authenticated_client, temp_stacks_dir, monkeypatch):
+        import stack_manager
+        original_path = stack_manager.STACKS_PATH
+        stack_manager.STACKS_PATH = temp_stacks_dir
+
+        stack_dir = os.path.join(temp_stacks_dir, "alpha")
+        os.makedirs(stack_dir, exist_ok=True)
+        with open(os.path.join(stack_dir, "compose.yaml"), "w") as f:
+            f.write("services: {}\n")
+
+        mock_run = MagicMock(returncode=0, stdout="log line\n", stderr="")
+        monkeypatch.setattr("stack_manager.subprocess.run", lambda *args, **kwargs: mock_run)
+
+        try:
+            response = authenticated_client.get("/api/stacks/alpha/logs?tail=20&service=web")
+            assert response.status_code == 200
+            data = response.get_json()
+            assert "log line" in data["logs"]
+            assert data["returncode"] == 0
+        finally:
+            stack_manager.STACKS_PATH = original_path
+
+    def test_stack_backups_and_restore(self, authenticated_client, temp_stacks_dir, monkeypatch):
+        import stack_manager
+        original_path = stack_manager.STACKS_PATH
+        original_backup = stack_manager.BACKUP_DIR
+        stack_manager.STACKS_PATH = temp_stacks_dir
+        stack_manager.BACKUP_DIR = os.path.join(temp_stacks_dir, ".backups")
+
+        stack_dir = os.path.join(temp_stacks_dir, "alpha")
+        os.makedirs(stack_dir, exist_ok=True)
+        with open(os.path.join(stack_dir, "compose.yaml"), "w") as f:
+            f.write("services:\n  web:\n    image: nginx\n")
+
+        backup_dir = os.path.join(stack_manager.BACKUP_DIR, "alpha")
+        os.makedirs(backup_dir, exist_ok=True)
+        backup_name = "compose-20240101010101.yaml"
+        with open(os.path.join(backup_dir, backup_name), "w") as f:
+            f.write("services:\n  web:\n    image: redis\n")
+
+        monkeypatch.setattr("stack_manager.backup_stack", lambda _name: "/tmp/backup")
+
+        try:
+            list_response = authenticated_client.get("/api/stacks/alpha/backups")
+            assert list_response.status_code == 200
+            assert backup_name in list_response.get_json()["backups"]
+
+            get_response = authenticated_client.get(f"/api/stacks/alpha/backups/{backup_name}")
+            assert get_response.status_code == 200
+            assert "redis" in get_response.get_json()["content"]
+
+            restore_response = authenticated_client.post(
+                "/api/stacks/alpha/restore",
+                data=json.dumps({"backup": backup_name}),
+                content_type="application/json",
+            )
+            assert restore_response.status_code == 200
+            assert restore_response.get_json()["status"] == "restored"
+        finally:
+            stack_manager.STACKS_PATH = original_path
+            stack_manager.BACKUP_DIR = original_backup
+
+    def test_stack_stream_routes(self, authenticated_client, monkeypatch):
+        monkeypatch.setattr(
+            "stack_manager.stream_compose_command",
+            lambda _name, _command: iter(['data: {"line":"ok"}\n\n', 'data: {"done":true}\n\n']),
+        )
+
+        up_response = authenticated_client.get("/api/stacks/alpha/up/stream")
+        assert up_response.status_code == 200
+        assert "done" in up_response.get_data(as_text=True)
+
+        pull_response = authenticated_client.get("/api/stacks/alpha/pull/stream")
+        assert pull_response.status_code == 200
+        assert "ok" in pull_response.get_data(as_text=True)
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/tests/test_storage_api.py
+++ b/tests/test_storage_api.py
@@ -97,6 +97,33 @@ class DummyMountPlugin:
         return {"status": "connected"}
 
 
+class DummySharePlugin(DummyPlugin):
+    def __init__(self):
+        super().__init__()
+        self.shares = [{"name": "media", "enabled": True}]
+
+    def get_status(self):
+        return {
+            "status": "healthy",
+            "message": "ok",
+            "service_running": True,
+            "details": {"shares": self.shares},
+        }
+
+    def add_share(self, share):
+        self.shares.append(share)
+        return CommandResult(success=True, message="added")
+
+    def update_share(self, share_name, share):
+        return CommandResult(success=True, message=f"updated {share_name}")
+
+    def remove_share(self, share_name):
+        return CommandResult(success=True, message=f"removed {share_name}")
+
+    def toggle_share(self, share_name, enabled):
+        return CommandResult(success=True, message=f"toggled {share_name}={enabled}")
+
+
 class DummyRegistry:
     def __init__(self, plugin=None, mount_plugin=None):
         self._plugin = plugin
@@ -110,6 +137,8 @@ class DummyRegistry:
             return self._plugin
         if plugin_id == "mount":
             return self._mount_plugin
+        if plugin_id == "share":
+            return self._plugin
         return None
 
     def set_plugin_enabled(self, plugin_id, enabled):
@@ -323,3 +352,142 @@ def test_mount_endpoints(authenticated_client, monkeypatch):
 
     response = authenticated_client.delete("/api/storage/mounts/mount/m1")
     assert response.status_code == 200
+
+
+def test_validate_plugin_config(authenticated_client, monkeypatch):
+    registry = DummyRegistry(plugin=DummyPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.post(
+        "/api/storage/plugins/dummy/validate",
+        data=json.dumps({"invalid": True}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["valid"] is False
+    assert "invalid config" in data["errors"][0]
+
+
+def test_apply_plugin_config_success(authenticated_client, monkeypatch):
+    registry = DummyRegistry(plugin=DummyPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.post("/api/storage/plugins/dummy/apply")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "applied"
+
+
+def test_apply_plugin_config_failure(authenticated_client, monkeypatch):
+    class FailingPlugin(DummyPlugin):
+        def apply_config(self):
+            return CommandResult(success=False, message="nope", error="apply failed")
+
+    registry = DummyRegistry(plugin=FailingPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.post("/api/storage/plugins/dummy/apply")
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "apply failed"
+
+
+def test_get_plugin_status(authenticated_client, monkeypatch):
+    registry = DummyRegistry(plugin=DummyPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.get("/api/storage/plugins/dummy/status")
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "healthy"
+
+
+def test_get_plugin_recovery_not_supported(authenticated_client, monkeypatch):
+    registry = DummyRegistry(plugin=DummyPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.get("/api/storage/plugins/dummy/recovery")
+    assert response.status_code == 404
+
+
+def test_get_plugin_recovery_supported(authenticated_client, monkeypatch):
+    class RecoverablePlugin(DummyPlugin):
+        def get_recovery_status(self):
+            return {"recoverable": True}
+
+    registry = DummyRegistry(plugin=RecoverablePlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.get("/api/storage/plugins/dummy/recovery")
+    assert response.status_code == 200
+    assert response.get_json()["recoverable"] is True
+
+
+def test_get_plugin_latest_log(authenticated_client, monkeypatch):
+    class LogPlugin(DummyPlugin):
+        def get_latest_log(self):
+            return {"content": "hello\n", "path": "/tmp/test.log", "truncated": False}
+
+    registry = DummyRegistry(plugin=LogPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.get("/api/storage/plugins/dummy/logs/latest")
+    assert response.status_code == 200
+    assert "hello" in response.get_data(as_text=True)
+    assert response.headers["X-Log-Path"] == "/tmp/test.log"
+    assert response.headers["X-Log-Truncated"] == "false"
+
+
+def test_detect_mounts_success(authenticated_client, monkeypatch):
+    class DetectingMountPlugin(DummyMountPlugin):
+        def import_existing_mounts(self):
+            return CommandResult(success=True, message="Imported", data={"imported": 1})
+
+    registry = DummyRegistry(mount_plugin=DetectingMountPlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.post("/api/storage/mounts/mount/detect")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["imported"] == 1
+
+
+def test_share_endpoints(authenticated_client, monkeypatch):
+    registry = DummyRegistry(plugin=DummySharePlugin())
+    monkeypatch.setattr("storage_plugins.get_registry", lambda: registry)
+
+    response = authenticated_client.get("/api/storage/shares/share")
+    assert response.status_code == 200
+    shares_payload = response.get_json()
+    assert shares_payload["service_running"] is True
+    assert shares_payload["shares"][0]["name"] == "media"
+
+    response = authenticated_client.post(
+        "/api/storage/shares/share",
+        data=json.dumps({"name": "downloads", "path": "/mnt/downloads"}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "created"
+
+    response = authenticated_client.put(
+        "/api/storage/shares/share/media",
+        data=json.dumps({"path": "/mnt/media"}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "updated"
+
+    response = authenticated_client.post(
+        "/api/storage/shares/share/media/toggle",
+        data=json.dumps({"enabled": False}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    toggle_data = response.get_json()
+    assert toggle_data["status"] == "toggled"
+    assert toggle_data["enabled"] is False
+
+    response = authenticated_client.delete("/api/storage/shares/share/media")
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "deleted"


### PR DESCRIPTION
## Summary
- backfill migrated pages to use shared state primitives from static/js/lib/states.js
- replace page-local loading/empty/error markup with shared helpers across shares, mounts, pools, plugins, network, and tailscale pages
- update Docs/UI_MIGRATION_TRACKER.md to mark shared-primitives backfill complete

## Testing
- pre-commit tox suite (ruff + pytest) passed during commit
- e2e is sandbox-skipped by script when app binding is blocked