### PR TITLE
🐛 Grant self-update write paths under helper sandbox

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -238,6 +238,10 @@ ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=/etc/fstab /etc/systemd/system /etc/sshfs /mnt /run/pihealth ${LIMEOS_LOG_DIR}
 ReadWritePaths=/backups
+# Self-update writes to the checkout (git pull, venv pip, npm build) and the
+# LimeOS runtime dirs (migration); ProtectHome/ProtectSystem block these
+# without explicit write paths.
+ReadWritePaths=${REPO_DIR} ${LIMEOS_CONFIG_DIR} ${LIMEOS_STATE_DIR}
 PrivateTmp=true
 
 # Socket permissions


### PR DESCRIPTION
## Why

Follow-up to #50. Live-testing the new streamed self-update on real hardware surfaced a blocker the tests couldn't catch: the privileged helper runs with `ProtectHome=read-only` and `ProtectSystem=strict`, so none of the update steps can write their targets. The `pull` step failed with:

```
error: cannot open '.git/FETCH_HEAD': Read-only file system
```

The checkout lives under `/home` (blocked by `ProtectHome`), and the runtime migration writes `/etc/limeos` and `/var/lib/limeos` (blocked by `ProtectSystem` — only the log dir was whitelisted). So `pull` / venv `pip` / `npm build` / `migrate` were all unable to write.

## What

Add the checkout dir and the LimeOS config/state dirs to the helper unit's `ReadWritePaths` (log dir was already present). `ReadWritePaths` punches through `ProtectHome`/`ProtectSystem` for just those subtrees, leaving the rest of the filesystem protected.

## Verification

Applied the same `ReadWritePaths` change to a running Pi and re-ran the streamed update end-to-end: the `pull` step now succeeds and reports "Already up to date (40cbcc50); no restart needed." Full tox gate (991 unit/integration + 97 e2e) green.

## Note for existing installs

Re-running `setup.sh` regenerates the helper unit. To patch in place without a full reinstall, add to `/etc/systemd/system/pihealth-helper.service`:

```
ReadWritePaths=<repo_dir> /etc/limeos /var/lib/limeos
```

then `systemctl daemon-reload && systemctl restart pihealth-helper.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)