### PR TITLE
✨ Acknowledge agent mentions in non-allowed channels

### DIFF
--- a/agent_transport/listener.py
+++ b/agent_transport/listener.py
@@ -33,6 +33,14 @@ logger = logging.getLogger("limeos.agent.listener")
 #: Safe under Mattermost's smallest common per-post limit (4000 chars).
 REPLY_CHUNK_CHARS = 3500
 
+#: Posted when the bot is explicitly @mentioned in a channel outside its allowlist.
+#: An explicit mention is always acknowledged rather than silently dropped, so the
+#: user is never left hanging waiting for a reply that will not come.
+OUT_OF_SCOPE_REPLY = (
+    "I'm not enabled to respond in this channel. An admin can enable it under "
+    "LimeOS → Integrations → Agents."
+)
+
 ReplyPoster = Callable[..., str]  # post_message(channel_id=, message=, root_id=) -> post id
 
 
@@ -84,11 +92,13 @@ class MentionListener:
     # -- per-frame handling (pure of I/O except posting) -----------------------
     def handle_frame(self, frame_text: str) -> bool:
         """Process one frame. Returns True when a turn was executed."""
+        # The channel allowlist is enforced here rather than inside parse_frame so
+        # that an explicit mention in a non-allowed channel is acknowledged (see
+        # _post_out_of_scope) instead of silently dropped.
         event = parse_frame(
             frame_text,
             bot_username=self._config.bot_username,
             bot_user_id=self._config.bot_user_id,
-            allowed_channels=self._config.allowed_channels,
         )
         if event is None:
             return False
@@ -97,8 +107,25 @@ class MentionListener:
         # Mark before executing so a crash mid-turn cannot double-run the same
         # mention after restart (losing one reply is safer than acting twice).
         self._dedup.mark(event.post_id)
+        if (
+            self._config.allowed_channels
+            and event.channel_id not in self._config.allowed_channels
+        ):
+            self._post_out_of_scope(event)
+            return False
         self._run_turn(event)
         return True
+
+    def _post_out_of_scope(self, event: MentionEvent) -> None:
+        """Acknowledge a mention in a non-allowed channel so the user isn't left hanging."""
+        try:
+            self._post_reply(
+                channel_id=event.channel_id,
+                message=OUT_OF_SCOPE_REPLY,
+                root_id=event.root_post_id,
+            )
+        except Exception:  # noqa: BLE001 - delivery failure must not kill the loop
+            logger.error("failed to post out-of-scope reply in %s", event.root_post_id)
 
     def _run_turn(self, event: MentionEvent) -> None:
         # On the first mention in a thread rooted elsewhere (e.g. an alert incident),

--- a/tests/test_agent_transport.py
+++ b/tests/test_agent_transport.py
@@ -18,6 +18,7 @@ from agent_transport.gateway_contract import (
     TurnResult,
 )
 from agent_transport.listener import (
+    OUT_OF_SCOPE_REPLY,
     ListenerConfig,
     MentionListener,
     chunk_reply,
@@ -338,6 +339,31 @@ def test_listener_same_thread_maps_to_same_conversation(tmp_path):
     listener.handle_frame(_frame("@limeos one", post_id="p1", root_id="root-1"))
     listener.handle_frame(_frame("@limeos two", post_id="p2", root_id="root-1"))
     assert gateway.requests[0].conversation_id == gateway.requests[1].conversation_id
+
+
+def test_listener_acknowledges_mention_outside_allowlist(tmp_path):
+    gateway, posts = FakeGateway(), []
+    listener = _listener(tmp_path, gateway, posts, allowed_channels=("chan-1",))
+    # Explicit mention in a non-allowed channel: acknowledged, agent never invoked.
+    assert listener.handle_frame(_frame("@limeos help", channel="other", root_id="root-9")) is False
+    assert gateway.requests == []
+    assert posts == [("other", "root-9", OUT_OF_SCOPE_REPLY)]
+
+
+def test_listener_runs_turn_inside_allowlist(tmp_path):
+    gateway, posts = FakeGateway(), []
+    listener = _listener(tmp_path, gateway, posts, allowed_channels=("chan-1",))
+    assert listener.handle_frame(_frame("@limeos status", channel="chan-1")) is True
+    assert len(gateway.requests) == 1  # allowed channel still runs the turn
+
+
+def test_listener_out_of_scope_reply_is_deduped(tmp_path):
+    gateway, posts = FakeGateway(), []
+    listener = _listener(tmp_path, gateway, posts, allowed_channels=("chan-1",))
+    frame = _frame("@limeos help", channel="other")
+    assert listener.handle_frame(frame) is False
+    assert listener.handle_frame(frame) is False  # replayed frame not re-acknowledged
+    assert len(posts) == 1
 
 
 def test_listener_posts_typed_public_message_on_turn_error(tmp_path):


### PR DESCRIPTION
## Why

The Mattermost assistant only acts in the channels listed in its `allowed_channels` allowlist — correct. But an explicit `@mention` in a channel *outside* that allowlist was dropped **silently** in `parse_frame`, so the user was left waiting for a reply that would never come.

This bit a real deployment: the bot was scoped to one channel (`LimeOS Alerts`) but users kept @mentioning it in another (`Stack Notifications`). No error, no reply — just silence, with nothing to indicate why.

## What

Move the channel-allowlist enforcement out of `parse_frame` and into `MentionListener.handle_frame`, so a mention in a non-allowed channel now gets a brief acknowledgement instead of silence:

> I'm not enabled to respond in this channel. An admin can enable it under LimeOS → Integrations → Agents.

- The agent is **still never invoked** outside its allowlist — only a static, LLM-free message is posted (no tools, no turn, no provider call).
- The acknowledgement is **deduped** like any other reply, so a websocket replay after reconnect won't re-post it.
- In-allowlist declines (daily invocation limit, turn errors) already post a public message via `_run_turn`, so **every path now acknowledges the mention** — the user is never left hanging.

`parse_frame` keeps its (still-tested) pure channel-filter capability; the listener just owns the decision now so it can respond on the reject path.

## Tests

New listener tests: out-of-scope mention is acknowledged without invoking the agent; in-allowlist mention still runs the turn; the out-of-scope acknowledgement is deduped. Full suite green (1694 tests).

## Note

The deployed agent runtime runs from an isolated venv, so existing installs need the agent runtime reinstalled/repaired to pick up this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)