### PR TITLE
🚑 fix: updater: defer agent convergence until restart

### DIFF
--- a/pihealth_update_service.py
+++ b/pihealth_update_service.py
@@ -127,18 +127,18 @@ def stream_update(helper_call: HelperCall, config: Mapping[str, Any]):
     else:
         yield {"step": "build", "line": "Web UI rebuilt."}
 
-    # -- AI agent runtime (only when agent code/config/baseline changed) -----
+    # -- AI agent runtime ----------------------------------------------------
+    # The app and helper are still running the pre-pull Python modules here. Running
+    # convergence now can mix that old installer with the newly pulled package tree.
+    # Both services restart below; app startup then calls agent_converge_if_stale using
+    # one coherent release.
     if any(path.startswith(_AGENT_UPDATE_PREFIXES) for path in changed):
-        yield {"step": "agent", "line": "Refreshing the AI agent runtime…"}
-        agent = call("agent")
-        if not agent.get("success"):
-            yield {"step": "agent", "error": agent.get("error", "agent refresh failed")}
-            return
         yield {
             "step": "agent",
-            "line": "Agent not installed; skipped."
-            if agent.get("skipped")
-            else "Agent runtime refreshed and package baseline reconciled.",
+            "line": (
+                "Agent runtime changes detected; refresh will continue automatically "
+                "after service restart."
+            ),
         }
     else:
         yield {"step": "agent", "line": "No agent changes."}

--- a/tests/test_pihealth_update_service.py
+++ b/tests/test_pihealth_update_service.py
@@ -142,34 +142,40 @@ def test_helper_exception_becomes_step_error():
     assert events[-1]["error"] == "helper offline"
 
 
-def test_agent_step_runs_when_agent_files_change():
+def test_agent_changes_defer_convergence_until_services_restart():
     helper, events = _run(
         {
             "pull": {"success": True, "old_commit": OLD, "new_commit": NEW,
                      "changed_files": ["agent_gateway/gateway.py", "config/limeos-packages.json"]},
             "migrate": {"success": True},
             "build": {"success": True, "skipped": True, "reason": "web UI already up to date"},
-            "agent": {"success": True, "refreshed": True},
             "restart": {"success": True},
         }
     )
-    assert helper.calls == ["pull", "migrate", "build", "agent", "restart"]
-    assert any(e["step"] == "agent" and "refreshed" in e.get("line", "") for e in events)
+    assert helper.calls == ["pull", "migrate", "build", "restart"]
+    assert any(
+        event["step"] == "agent"
+        and "after service restart" in event.get("line", "").lower()
+        for event in events
+    )
 
 
-def test_agent_step_reports_skip_when_not_installed():
+def test_agent_changes_do_not_run_with_the_pre_pull_helper():
     helper, events = _run(
         {
             "pull": {"success": True, "old_commit": OLD, "new_commit": NEW,
                      "changed_files": ["limeos_packages.py"]},
             "migrate": {"success": True},
             "build": {"success": True, "skipped": True, "reason": "web UI already up to date"},
-            "agent": {"success": True, "skipped": True, "reason": "agent not installed"},
             "restart": {"success": True},
         }
     )
-    assert "agent" in helper.calls
-    assert any(e["step"] == "agent" and "skipped" in e.get("line", "").lower() for e in events)
+    assert "agent" not in helper.calls
+    assert helper.calls[-1] == "restart"
+    assert any(
+        event["step"] == "agent" and "automatically" in event.get("line", "")
+        for event in events
+    )
 
 
 def test_agent_step_not_called_without_agent_changes():
@@ -186,15 +192,17 @@ def test_agent_step_not_called_without_agent_changes():
     assert any(e["step"] == "agent" and "No agent changes" in e.get("line", "") for e in events)
 
 
-def test_agent_step_error_stops_before_restart():
+def test_agent_changes_cannot_block_the_release_restart():
     helper, events = _run(
         {
             "pull": {"success": True, "old_commit": OLD, "new_commit": NEW,
                      "changed_files": ["agent_transport/listener.py"]},
             "migrate": {"success": True},
             "build": {"success": True, "skipped": True, "reason": "web UI already up to date"},
-            "agent": {"success": False, "error": "agent refresh failed"},
+            "restart": {"success": True},
         }
     )
-    assert events[-1]["step"] == "agent" and events[-1]["error"] == "agent refresh failed"
-    assert "restart" not in helper.calls
+    assert "agent" not in helper.calls
+    assert helper.calls[-1] == "restart"
+    assert events[-1]["step"] == "restart"
+    assert events[-1]["done"] is True


### PR DESCRIPTION
- File(s) changed: pihealth_update_service.py, tests/test_pihealth_update_service.py

- Nature of changes: Prevent mixed-version runtime installation

- Purpose: Restart the app and helper onto the pulled release before agent convergence

- Impact: Code updates reach their restart phase and report the deferred refresh clearly