### PR TITLE
🚑 Fix isolated AO action broker runtime

### DIFF
--- a/agent_actions/server.py
+++ b/agent_actions/server.py
@@ -28,6 +28,7 @@ from agent_actions.integrations import (
 from agent_actions.ledger import ActionLedger
 from agent_actions.packages import package_job_status, package_repair_status
 from agent_actions.policy import ActionPolicy, ActionPolicyError
+from agent_actions.stack_runtime import default_stack_operations_service
 from container_operations_service import ContainerOperationsService
 from helper_client import HelperError, helper_call
 from limeops.broker import JsonlAuditWriter, LimeOpsBroker
@@ -35,7 +36,6 @@ from limeops.policy import LimeOpsPolicy, PolicyError
 from limeops.server import LimeOpsUnixServer
 from limeops.wiring import _container_action_status, _stack_inspect
 from ports import DockerClientAdapter
-from stack_manager import default_stack_operations_service
 
 
 DEFAULT_SOCKET_PATH = "/run/limeos-actions/actions.sock"

--- a/agent_actions/stack_runtime.py
+++ b/agent_actions/stack_runtime.py
@@ -1,0 +1,91 @@
+"""Framework-neutral stack adapters for the isolated action runtime."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import re
+import subprocess
+import threading
+from contextlib import contextmanager
+
+from stack_operations_service import StackOperationsService
+from stack_read_service import StackReadService
+
+
+STACKS_PATH = os.getenv("STACKS_PATH", "/opt/stacks")
+BACKUP_DIR = os.getenv("STACK_BACKUP_DIR", os.path.join(STACKS_PATH, ".backups"))
+STACK_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+_stack_lock_state = threading.local()
+
+
+def validate_stack_name(name: str) -> tuple[bool, str | None]:
+    """Validate a stack or service name before passing it to Docker Compose."""
+    if not name:
+        return False, "Stack name is required"
+    if not STACK_NAME_RE.fullmatch(name):
+        return False, "Stack name contains unsupported characters"
+    if ".." in name or name.startswith("."):
+        return False, "Invalid stack name"
+    if len(name) > 64:
+        return False, "Stack name too long (max 64 characters)"
+    return True, None
+
+
+@contextmanager
+def stack_lock(name: str):
+    """Hold the same reentrant, inter-process lock used by dashboard mutations."""
+    valid, error = validate_stack_name(name)
+    if not valid:
+        raise ValueError(error)
+    lock_dir = os.path.join(STACKS_PATH, ".locks")
+    os.makedirs(lock_dir, mode=0o2770, exist_ok=True)
+    lock_path = os.path.abspath(os.path.join(lock_dir, f"{name}.lock"))
+
+    current_pid = os.getpid()
+    if getattr(_stack_lock_state, "pid", None) != current_pid:
+        _stack_lock_state.pid = current_pid
+        _stack_lock_state.held_locks = {}
+    held_locks = getattr(_stack_lock_state, "held_locks", None)
+    if held_locks is None:
+        held_locks = {}
+        _stack_lock_state.held_locks = held_locks
+    held = held_locks.get(lock_path)
+    if held:
+        held["depth"] += 1
+        try:
+            yield
+        finally:
+            held["depth"] -= 1
+        return
+
+    lock_file = open(lock_path, "a+")
+    try:
+        os.chmod(lock_path, 0o660)
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        held_locks[lock_path] = {"file": lock_file, "depth": 1}
+        try:
+            yield
+        finally:
+            held_locks.pop(lock_path, None)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        lock_file.close()
+
+
+def default_stack_read_service() -> StackReadService:
+    return StackReadService(
+        stacks_path_provider=lambda: STACKS_PATH,
+        backup_path_provider=lambda: BACKUP_DIR,
+        command_runner=lambda command, **kwargs: subprocess.run(command, **kwargs),
+    )
+
+
+def default_stack_operations_service() -> StackOperationsService:
+    return StackOperationsService(
+        stacks_path_provider=lambda: STACKS_PATH,
+        lock_provider=lambda name: stack_lock(name),
+        command_runner=lambda command, **kwargs: subprocess.run(command, **kwargs),
+        process_factory=lambda command, **kwargs: subprocess.Popen(command, **kwargs),
+        service_name_validator=validate_stack_name,
+    )

--- a/agent_provider/provisioning.py
+++ b/agent_provider/provisioning.py
@@ -19,6 +19,7 @@ ACTION_STATE_DIR = "/var/lib/limeos/agent-actions"
 ACTION_SOCKET_DIR = "/run/limeos-actions"
 ACTION_SOCKET_PATH = "/run/limeos-actions/actions.sock"
 ACTION_AUDIT_PATH = "/var/log/limeos/agent-action-audit.jsonl"
+STACK_LOCK_DIR = "/opt/stacks/.locks"
 AGENT_UNIT_PATH = "/etc/systemd/system/limeos-agent.service"
 LIMEOPS_UNIT_PATH = "/etc/systemd/system/limeopsd.service"
 ACTION_BROKER_UNIT_PATH = "/etc/systemd/system/limeops-actuatord.service"
@@ -26,6 +27,24 @@ ACTION_WORKER_UNIT_PATH = "/etc/systemd/system/limeops-action-worker.service"
 AGENT_REPAIR_UNIT_PATH = "/etc/systemd/system/limeos-agent-repair.service"
 EXTENSION_REPAIR_UNIT_PATH = "/etc/systemd/system/limeos-extension-repair@.service"
 MATTERMOST_REPAIR_UNIT_PATH = "/etc/systemd/system/limeos-mattermost-repair.service"
+
+AGENT_RUNTIME_PACKAGES = (
+    "agent_actions",
+    "agent_findings",
+    "agent_gateway",
+    "agent_provider",
+    "agent_runtime",
+    "agent_transport",
+    "limeops",
+)
+AGENT_RUNTIME_MODULES = (
+    "container_operations_service.py",
+    "helper_client.py",
+    "ports.py",
+    "runtime_paths.py",
+    "stack_operations_service.py",
+    "stack_read_service.py",
+)
 
 
 def render_agent_unit(repo_dir: str, python_bin: str) -> str:
@@ -65,7 +84,7 @@ LockPersonality=true
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 ReadOnlyPaths={AGENT_LIB_DIR}
 ReadWritePaths={AGENT_STATE_DIR} {CLAUDE_CONFIG_DIR}
-InaccessiblePaths=/root {repo_dir} /run/pihealth {ACTION_SOCKET_DIR} /var/run/docker.sock /etc/limeos/credentials.env
+InaccessiblePaths=/root {repo_dir} /run/pihealth -{ACTION_SOCKET_DIR} /var/run/docker.sock /etc/limeos/credentials.env
 CapabilityBoundingSet=
 SystemCallArchitectures=native
 
@@ -145,7 +164,7 @@ RestrictRealtime=true
 LockPersonality=true
 RestrictAddressFamilies=AF_UNIX
 ReadOnlyPaths={AGENT_LIB_DIR} {ACTION_POLICY_PATH} {ACTION_BROKER_POLICY_PATH}
-ReadWritePaths={ACTION_SOCKET_DIR} {ACTION_STATE_DIR} /var/log/limeos
+ReadWritePaths={ACTION_SOCKET_DIR} {ACTION_STATE_DIR} /var/log/limeos {STACK_LOCK_DIR}
 InaccessiblePaths=/root {repo_dir} /run/pihealth /etc/limeos/credentials.env
 CapabilityBoundingSet=
 

--- a/limeops/wiring.py
+++ b/limeops/wiring.py
@@ -161,7 +161,7 @@ def _container_logs(name: str, lines: int) -> str:  # pragma: no cover - target 
 
 
 def _stack_reads():  # pragma: no cover - target integration
-    from stack_manager import default_stack_read_service
+    from agent_actions.stack_runtime import default_stack_read_service
 
     return default_stack_read_service()
 
@@ -181,14 +181,32 @@ def _stack_status(name: str) -> dict:  # pragma: no cover - target integration
 
 
 def _stack_inspect(name: str) -> dict:  # pragma: no cover - target integration
-    from compose_yaml import load_compose_yaml
     from limeops.operations import sanitize_stack_details
 
     details = _stack_reads().stack_details(name)
     try:
-        compose = load_compose_yaml(details.get("compose_content") or "") or {}
-    except Exception:
-        compose = {}
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                details["compose_file"],
+                "config",
+                "--format",
+                "json",
+            ],
+            cwd=details["path"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            shell=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError("Docker Compose configuration is unavailable")
+        compose = json.loads(result.stdout)
+    except (KeyError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Docker Compose returned invalid configuration") from exc
     # sanitize_stack_details keeps structure and env KEYS only — raw compose_content
     # and env_content never leave this function.
     return sanitize_stack_details(details, compose)

--- a/pihealth_helper.py
+++ b/pihealth_helper.py
@@ -3630,7 +3630,10 @@ def cmd_agent_runtime_install(params):
 
 
 def _agent_repo_commit(repo_dir):
-    result = run_command(['git', '-C', repo_dir, 'rev-parse', 'HEAD'])
+    dashboard_user = _agent_dashboard_user(repo_dir)
+    if not dashboard_user:
+        return ''
+    result = _git_as(dashboard_user, repo_dir, 'rev-parse', 'HEAD')
     return (result.get('stdout') or '').strip() if result.get('returncode') == 0 else ''
 
 

--- a/pihealth_helper.py
+++ b/pihealth_helper.py
@@ -46,7 +46,6 @@ from agent_provider.provisioning import (
     ACTION_BROKER_POLICY_PATH,
     ACTION_BROKER_UNIT_PATH,
     ACTION_POLICY_PATH,
-    ACTION_SOCKET_DIR,
     ACTION_SOCKET_PATH,
     ACTION_STATE_DIR,
     ACTION_WORKER_UNIT_PATH,
@@ -56,16 +55,18 @@ from agent_provider.provisioning import (
     AGENT_ENV_PATH,
     AGENT_LIB_DIR,
     AGENT_POLICY_PATH,
+    AGENT_RUNTIME_MODULES,
+    AGENT_RUNTIME_PACKAGES,
     AGENT_STATE_DIR,
     AGENT_UNIT_PATH,
     AGENT_VENV_DIR,
     CLAUDE_CONFIG_DIR,
     LIMEOPS_AUDIT_PATH,
-    LIMEOPS_SOCKET_DIR,
     LIMEOPS_SOCKET_PATH,
     LIMEOPS_STATE_DIR,
     LIMEOPS_UNIT_PATH,
     MATTERMOST_REPAIR_UNIT_PATH,
+    STACK_LOCK_DIR,
     render_agent_unit,
     render_action_broker_unit,
     render_action_worker_unit,
@@ -3300,6 +3301,41 @@ def _agent_install_directory(path, mode, owner, group):
     return result.get('returncode') == 0
 
 
+def _secure_agent_stack_locks(dashboard_user):
+    """Make only validated stack lock files writable by the shared pihealth group."""
+    import grp
+
+    try:
+        owner_uid = pwd.getpwnam(dashboard_user).pw_uid
+        group_gid = grp.getgrnam('pihealth').gr_gid
+        entries = list(os.scandir(STACK_LOCK_DIR))
+    except (KeyError, OSError):
+        return False
+    for entry in entries:
+        if (
+            not re.fullmatch(r'[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}\.lock', entry.name)
+            or '..' in entry.name
+        ):
+            return False
+        try:
+            descriptor = os.open(
+                entry.path,
+                os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+            )
+        except OSError:
+            return False
+        try:
+            if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+                return False
+            os.fchown(descriptor, owner_uid, group_gid)
+            os.fchmod(descriptor, 0o660)
+        except OSError:
+            return False
+        finally:
+            os.close(descriptor)
+    return True
+
+
 def _restore_mattermost_recovery_ownership():
     """Restore the fixed root-only recovery path after broad legacy migration."""
     try:
@@ -3427,27 +3463,20 @@ def cmd_agent_runtime_install(params):
         ('/var/lib/lime-agent', 0o700, 'lime-agent', 'lime-agent'),
         (CLAUDE_CONFIG_DIR, 0o700, 'lime-agent', 'lime-agent'),
         (LIMEOPS_STATE_DIR, 0o750, 'limeops', 'limeops'),
-        (LIMEOPS_SOCKET_DIR, 0o750, 'limeops', 'limeops-client'),
         (ACTION_STATE_DIR, 0o770, 'limeops-actuator', 'pihealth'),
-        (ACTION_SOCKET_DIR, 0o750, 'limeops-actuator', 'limeops-action'),
+        (STACK_LOCK_DIR, 0o2770, dashboard_user, 'pihealth'),
     )
     if not all(_agent_install_directory(*item) for item in directories):
         return {'success': False, 'error': 'Failed to create agent runtime directories'}
+    if not _secure_agent_stack_locks(dashboard_user):
+        return {'success': False, 'error': 'Failed to secure shared stack locks'}
 
     python_bin = os.path.join(repo_dir, '.venv', 'bin', 'python')
     if not os.path.isfile(python_bin):
         return {'success': False, 'error': 'LimeOS virtual environment is unavailable'}
     if not _agent_install_directory(AGENT_LIB_DIR, 0o755, 'root', 'root'):
         return {'success': False, 'error': 'Failed to create the agent runtime library'}
-    for package in (
-        'agent_actions',
-        'agent_findings',
-        'agent_gateway',
-        'agent_provider',
-        'agent_runtime',
-        'agent_transport',
-        'limeops',
-    ):
+    for package in AGENT_RUNTIME_PACKAGES:
         source = os.path.join(repo_dir, package)
         destination = os.path.join(AGENT_LIB_DIR, package)
         if not os.path.isdir(source):
@@ -3466,12 +3495,7 @@ def cmd_agent_runtime_install(params):
         manifest_source = os.path.join(repo_dir, 'config', 'limeos-packages.json')
         if os.path.isfile(manifest_source):
             shutil.copy2(manifest_source, os.path.join(manifest_dir, 'limeos-packages.json'))
-        for module_name in (
-            'container_operations_service.py',
-            'helper_client.py',
-            'ports.py',
-            'runtime_paths.py',
-        ):
+        for module_name in AGENT_RUNTIME_MODULES:
             module_source = os.path.join(repo_dir, module_name)
             if not os.path.isfile(module_source):
                 raise OSError('Action runtime module is unavailable')

--- a/scripts/migrate_runtime_state.py
+++ b/scripts/migrate_runtime_state.py
@@ -13,6 +13,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from runtime_paths import migrate_legacy_runtime_data
+from agent_provider.provisioning import STACK_LOCK_DIR
 
 
 HELPER_RESTART_DROPIN = "restart-with-pi-health.conf"
@@ -36,6 +37,26 @@ def ensure_agent_runtime_roots() -> None:
             "-p",
             "/var/lib/lime-agent",
             "/var/lib/limeops",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "systemd-run",
+            "--quiet",
+            "--wait",
+            "--pipe",
+            "--collect",
+            "--service-type=exec",
+            "/usr/bin/install",
+            "-d",
+            "-o",
+            "root",
+            "-g",
+            "pihealth",
+            "-m",
+            "2770",
+            STACK_LOCK_DIR,
         ],
         check=True,
     )
@@ -190,7 +211,8 @@ def ensure_helper_agent_permissions(
         f"Environment=PIHEALTH_REPO_DIR={repo_dir.resolve()}\n"
         "ReadWritePaths=/etc/apt\n"
         "ReadWritePaths=/usr /var/lib/apt /var/lib/dpkg /var/cache/apt\n"
-        "ReadWritePaths=-/var/lib/lime-agent -/var/lib/limeops -/run/limeos\n"
+        "ReadWritePaths=-/var/lib/lime-agent -/var/lib/limeops "
+        f"-{STACK_LOCK_DIR}\n"
     )
     return _ensure_helper_dropin(systemd_dir, HELPER_AGENT_DROPIN, content)
 

--- a/stack_manager.py
+++ b/stack_manager.py
@@ -64,7 +64,7 @@ def handle_compose_file_conflict(error):
 
 def _stack_lock_path(name):
     lock_dir = os.path.join(STACKS_PATH, '.locks')
-    os.makedirs(lock_dir, mode=0o700, exist_ok=True)
+    os.makedirs(lock_dir, mode=0o2770, exist_ok=True)
     return os.path.join(lock_dir, f'{name}.lock')
 
 
@@ -96,7 +96,7 @@ def stack_lock(name):
 
     lock_file = open(lock_path, 'a+')
     try:
-        os.chmod(lock_path, 0o600)
+        os.chmod(lock_path, 0o660)
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
         held_locks[lock_path] = {'file': lock_file, 'depth': 1}
         try:

--- a/tests/test_agent_provisioning.py
+++ b/tests/test_agent_provisioning.py
@@ -510,6 +510,22 @@ def test_installed_runtime_can_import_action_broker_without_dashboard_source(tmp
     assert result.returncode == 0, result.stderr
 
 
+def test_agent_repo_commit_runs_git_as_dashboard_owner():
+    with (
+        patch.object(helper, "_agent_dashboard_user", return_value="holly"),
+        patch.object(
+            helper,
+            "_git_as",
+            return_value={"returncode": 0, "stdout": "abc123\n"},
+        ) as git_as,
+    ):
+        assert helper._agent_repo_commit("/home/holly/pi-health") == "abc123"
+
+    git_as.assert_called_once_with(
+        "holly", "/home/holly/pi-health", "rev-parse", "HEAD"
+    )
+
+
 def test_shared_stack_locks_reject_unexpected_entries(tmp_path):
     (tmp_path / "media.lock").touch()
     (tmp_path / "unexpected").touch()

--- a/tests/test_agent_provisioning.py
+++ b/tests/test_agent_provisioning.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import stat
+import subprocess
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pihealth_helper as helper
@@ -17,6 +22,8 @@ from agent_provider.provisioning import (
     ACTION_STATE_DIR,
     ACTION_WORKER_UNIT_PATH,
     AGENT_REPAIR_UNIT_PATH,
+    AGENT_RUNTIME_MODULES,
+    AGENT_RUNTIME_PACKAGES,
     EXTENSION_REPAIR_UNIT_PATH,
     AGENT_ENV_PATH,
     AGENT_LIB_DIR,
@@ -24,6 +31,7 @@ from agent_provider.provisioning import (
     CLAUDE_CONFIG_DIR,
     LIMEOPS_STATE_DIR,
     MATTERMOST_REPAIR_UNIT_PATH,
+    STACK_LOCK_DIR,
     render_agent_unit,
     render_action_broker_unit,
     render_action_worker_unit,
@@ -52,7 +60,7 @@ def test_agent_unit_has_no_privileged_sockets_or_source_access():
     assert f"ReadWritePaths={AGENT_STATE_DIR} {CLAUDE_CONFIG_DIR}" in unit
     assert f"ReadOnlyPaths={AGENT_LIB_DIR}" in unit
     assert (
-        "InaccessiblePaths=/root /opt/pi-health /run/pihealth /run/limeos-actions "
+        "InaccessiblePaths=/root /opt/pi-health /run/pihealth -/run/limeos-actions "
         "/var/run/docker.sock "
         "/etc/limeos/credentials.env"
     ) in unit
@@ -92,6 +100,7 @@ def test_action_units_keep_worker_unprivileged_and_socket_separate():
     assert "agent-action-policy.json" in broker
     assert "agent-actuator-policy.json" in broker
     assert ACTION_SOCKET_DIR in broker
+    assert f"ReadWritePaths={ACTION_SOCKET_DIR} {ACTION_STATE_DIR} /var/log/limeos {STACK_LOCK_DIR}" in broker
     assert "User=limeops-action-worker" in worker
     assert "SupplementaryGroups=pihealth limeops-action" in worker
     assert "python3 -m agent_actions.worker" in worker
@@ -417,6 +426,7 @@ def test_runtime_install_creates_fixed_identities_paths_and_units(tmp_path):
         patch.object(helper.os, "makedirs"),
         patch.object(helper.os.path, "isdir", return_value=True),
         patch.object(helper.os.path, "isfile", return_value=True),
+        patch.object(helper, "_secure_agent_stack_locks", return_value=True),
     ):
         result = helper.cmd_agent_runtime_install({})
 
@@ -457,7 +467,8 @@ def test_runtime_install_creates_fixed_identities_paths_and_units(tmp_path):
     assert any(CLAUDE_CONFIG_DIR in command for command in install_dirs)
     assert any(LIMEOPS_STATE_DIR in command for command in install_dirs)
     assert any(ACTION_STATE_DIR in command for command in install_dirs)
-    assert any(ACTION_SOCKET_DIR in command for command in install_dirs)
+    assert any(STACK_LOCK_DIR in command and "2770" in command for command in install_dirs)
+    assert not any(ACTION_SOCKET_DIR in command for command in install_dirs)
     assert ["chmod", "-R", "u=rwX,go=rX", AGENT_LIB_DIR] in commands
     assert ["systemctl", "restart", "limeopsd.service"] in commands
     assert ["systemctl", "restart", "limeops-actuatord.service"] in commands
@@ -466,6 +477,66 @@ def test_runtime_install_creates_fixed_identities_paths_and_units(tmp_path):
     assert [
         "apt-get", "install", "-y", "python3-psutil", "python3-docker"
     ] in commands
+
+
+def test_installed_runtime_can_import_action_broker_without_dashboard_source(tmp_path):
+    repo = Path(__file__).parents[1]
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    for package in AGENT_RUNTIME_PACKAGES:
+        shutil.copytree(repo / package, runtime / package)
+    for module in AGENT_RUNTIME_MODULES:
+        shutil.copy2(repo / module, runtime / module)
+    shutil.copy2(repo / "limeos_packages.py", runtime / "limeos_packages.py")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(runtime)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from agent_actions.server import _build_actuator; "
+                "_build_actuator('policy.json', 'actions.sqlite3')"
+            ),
+        ],
+        cwd=runtime,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_shared_stack_locks_reject_unexpected_entries(tmp_path):
+    (tmp_path / "media.lock").touch()
+    (tmp_path / "unexpected").touch()
+    with (
+        patch.object(helper, "STACK_LOCK_DIR", str(tmp_path)),
+        patch.object(helper.pwd, "getpwnam", return_value=SimpleNamespace(pw_uid=1000)),
+        patch("grp.getgrnam", return_value=SimpleNamespace(gr_gid=1001)),
+        patch.object(helper.os, "fchown") as fchown,
+    ):
+        assert helper._secure_agent_stack_locks("holly") is False
+    fchown.assert_not_called()
+
+
+def test_shared_stack_locks_are_group_writable(tmp_path):
+    lock = tmp_path / "media.lock"
+    lock.touch()
+    with (
+        patch.object(helper, "STACK_LOCK_DIR", str(tmp_path)),
+        patch.object(helper.pwd, "getpwnam", return_value=SimpleNamespace(pw_uid=1000)),
+        patch("grp.getgrnam", return_value=SimpleNamespace(gr_gid=1001)),
+        patch.object(helper.os, "fchown") as fchown,
+        patch.object(helper.os, "fchmod") as fchmod,
+    ):
+        assert helper._secure_agent_stack_locks("holly") is True
+    descriptor = fchown.call_args.args[0]
+    fchown.assert_called_once_with(descriptor, 1000, 1001)
+    fchmod.assert_called_once_with(descriptor, 0o660)
 
 
 def test_broker_state_requires_the_limeops_socket():

--- a/tests/test_limeops_wiring.py
+++ b/tests/test_limeops_wiring.py
@@ -88,3 +88,67 @@ def test_action_container_status_adds_private_fingerprint_fields(monkeypatch):
     assert status["image_id"] == "sha256:image-id"
     assert status["started_at"] == "2026-07-21T10:00:00Z"
     assert "id" not in wiring._container_summary(inspect_data[0])
+
+
+def test_stack_inspect_uses_compose_json_and_never_returns_secret_values(monkeypatch):
+    calls = []
+    details = {
+        "name": "media",
+        "path": "/opt/stacks/media",
+        "compose_file": "compose.yaml",
+        "compose_content": "secret source",
+        "has_env": True,
+        "env_content": "TOKEN=secret",
+        "status": {"status": "running", "containers": []},
+    }
+    compose = {
+        "services": {
+            "jellyfin": {
+                "image": "jellyfin:latest",
+                "environment": {"TOKEN": "secret"},
+            }
+        }
+    }
+
+    class StackReads:
+        @staticmethod
+        def stack_details(name):
+            assert name == "media"
+            return details
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _completed(json.dumps(compose))
+
+    monkeypatch.setattr(wiring, "_stack_reads", lambda: StackReads())
+    monkeypatch.setattr(wiring.subprocess, "run", run)
+
+    result = wiring._stack_inspect("media")
+
+    assert result == {
+        "name": "media",
+        "compose_file": "compose.yaml",
+        "has_env": True,
+        "status": {"status": "running", "containers": []},
+        "services": [
+            {
+                "name": "jellyfin",
+                "image": "jellyfin:latest",
+                "ports": [],
+                "restart": "",
+                "depends_on": [],
+                "environment_keys": ["TOKEN"],
+            }
+        ],
+    }
+    assert "secret" not in json.dumps(result)
+    assert calls[0][0] == [
+        "docker",
+        "compose",
+        "-f",
+        "compose.yaml",
+        "config",
+        "--format",
+        "json",
+    ]
+    assert calls[0][1]["cwd"] == "/opt/stacks/media"

--- a/tests/test_migrate_runtime_state_script.py
+++ b/tests/test_migrate_runtime_state_script.py
@@ -29,6 +29,7 @@ def test_agent_runtime_roots_are_seeded_outside_helper_mount_sandbox(monkeypatch
 
     ensure_agent_runtime_roots()
 
+    assert len(calls) == 2
     argv, kwargs = calls[0]
     assert argv[:6] == [
         "systemd-run",
@@ -40,6 +41,18 @@ def test_agent_runtime_roots_are_seeded_outside_helper_mount_sandbox(monkeypatch
     ]
     assert argv[-3:] == ["-p", "/var/lib/lime-agent", "/var/lib/limeops"]
     assert kwargs == {"check": True}
+    lock_argv, lock_kwargs = calls[1]
+    assert lock_argv[-8:] == [
+        "-d",
+        "-o",
+        "root",
+        "-g",
+        "pihealth",
+        "-m",
+        "2770",
+        "/opt/stacks/.locks",
+    ]
+    assert lock_kwargs == {"check": True}
 
 
 def test_integration_recovery_root_is_seeded_with_root_only_permissions(monkeypatch):
@@ -110,7 +123,9 @@ def test_helper_agent_permissions_are_created_and_idempotent(tmp_path: Path):
     assert "ReadWritePaths=/etc/apt" in content
     assert "/etc/passwd" not in content
     assert "ReadWritePaths=/usr /var/lib/apt /var/lib/dpkg /var/cache/apt" in content
-    assert "ReadWritePaths=-/var/lib/lime-agent -/var/lib/limeops -/run/limeos" in content
+    assert "ReadWritePaths=-/var/lib/lime-agent -/var/lib/limeops" in content
+    assert "-/opt/stacks/.locks" in content
+    assert "/run/limeos" not in content
     assert "StateDirectory=" not in content
     assert "RuntimeDirectory=" not in content
     assert dropin.stat().st_mode & 0o777 == 0o644


### PR DESCRIPTION
## What changed

- deploy a framework-neutral stack adapter with the isolated agent runtime
- replace the action broker's Flask dashboard import
- read Compose structure through bounded JSON output
- let systemd own transient broker socket directories
- provision shared, group-writable stack locks without following symlinks
- read the deployed release through Git as the dashboard repository owner

## Root cause

The actuator copied only its isolated runtime packages, but imported `stack_manager`, which belongs to the Flask dashboard source tree. It therefore crashed at startup with `ModuleNotFoundError`. Its restart loop removed `/run/limeos-actions`, while the read-only agent treated that transient path as mandatory. Stack reconciliation would also have failed because its shared lock files were mode `0600`.

## Impact

The actuator and worker can start from `/usr/lib/limeos-agent`, inspect and reconcile existing stacks within the fixed policy boundary, and restart without taking down the read-only agent. Startup convergence also records the deployed commit on repositories protected by Git's safe-directory check.

## Validation

- isolated deployed-tree actuator construction regression
- focused provisioning, LimeOps, action, stack, migration, and lock-concurrency tests
- `tox -e all`: 1,982 passed, 1 skipped; 163 browser tests passed
