### PR TITLE
🚑 Fix AO runtime convergence and shared ledger

### DIFF
--- a/agent_actions/ledger.py
+++ b/agent_actions/ledger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import stat
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -199,7 +200,15 @@ class ActionLedger:
                 connection.executescript(_SCHEMA)
             # The dashboard, proposal broker, and isolated actuator are separate
             # service identities in the trusted ``pihealth`` state group.
-            os.chmod(self._path, 0o660)
+            try:
+                os.chmod(self._path, 0o660)
+            except PermissionError:
+                metadata = self._path.stat(follow_symlinks=False)
+                if (
+                    not stat.S_ISREG(metadata.st_mode)
+                    or stat.S_IMODE(metadata.st_mode) != 0o660
+                ):
+                    raise
         except (OSError, sqlite3.Error) as exc:
             raise ActionLedgerError("store_unavailable", "Action ledger is unavailable") from exc
 

--- a/runtime_paths.py
+++ b/runtime_paths.py
@@ -45,7 +45,7 @@ def ensure_runtime_directories(
     log_dir: Path = LOG_DIR,
 ) -> None:
     """Create runtime roots with service-private directory permissions."""
-    for path in (config_dir, state_dir, log_dir):
+    for path in (config_dir, state_dir, log_dir, state_dir / "integrations"):
         path.mkdir(parents=True, exist_ok=True, mode=0o750)
         path.chmod(0o750)
 

--- a/tests/test_agent_actions.py
+++ b/tests/test_agent_actions.py
@@ -220,6 +220,41 @@ def test_ledger_is_private_and_idempotent(tmp_path):
     assert os.stat(tmp_path / "state" / "actions.sqlite3").st_mode & 0o777 == 0o660
 
 
+def test_ledger_accepts_secure_group_file_owned_by_another_identity(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "actions.sqlite3"
+    ActionLedger(path)
+    real_chmod = os.chmod
+
+    def deny_database_chmod(target, mode, *args, **kwargs):
+        if os.fspath(target) == os.fspath(path):
+            raise PermissionError("owned by another service identity")
+        return real_chmod(target, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "chmod", deny_database_chmod)
+
+    ActionLedger(path)
+
+
+def test_ledger_rejects_insecure_file_owned_by_another_identity(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "actions.sqlite3"
+    ActionLedger(path)
+    path.chmod(0o666)
+
+    def deny_chmod(*_args, **_kwargs):
+        raise PermissionError("owned by another service identity")
+
+    monkeypatch.setattr(os, "chmod", deny_chmod)
+
+    with pytest.raises(ActionLedgerError) as unavailable:
+        ActionLedger(path)
+
+    assert unavailable.value.code == "store_unavailable"
+
+
 def test_ledger_rejects_idempotency_payload_conflict(tmp_path):
     ledger = ActionLedger(tmp_path / "actions.sqlite3")
     ledger.create(_new_action())

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -7,6 +7,24 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from runtime_paths import migrate_legacy_runtime_data
 
 
+def test_migration_secures_existing_integration_lifecycle_directory(tmp_path):
+    state_dir = tmp_path / "state"
+    integrations_dir = state_dir / "integrations"
+    integrations_dir.mkdir(parents=True, mode=0o755)
+    integrations_dir.chmod(0o755)
+
+    migrate_legacy_runtime_data(
+        source_root=tmp_path / "source",
+        config_dir=tmp_path / "config",
+        state_dir=state_dir,
+        log_dir=tmp_path / "log",
+        legacy_credentials=tmp_path / "missing.env",
+        credentials_file=tmp_path / "config" / "credentials.env",
+    )
+
+    assert integrations_dir.stat().st_mode & 0o777 == 0o750
+
+
 def test_migration_routes_config_state_logs_and_credentials(tmp_path):
     source_root = tmp_path / "source"
     legacy_config = source_root / "config"


### PR DESCRIPTION
## What changed

- enforce mode `0750` on the agent integration lifecycle directory during runtime migration
- allow isolated action services to open an existing `0660` ledger owned by another identity in the trusted `pihealth` group
- retain strict validation: denied ownership changes are accepted only for a regular file already using exactly `0660`

## Root cause

Holly's existing lifecycle directory retained mode `0755`, so the lifecycle snapshot reported `cleanup_required` and skipped agent convergence after an update. Once that directory was repaired, the actuator and worker reached the refreshed runtime but crash-looped because each tried to `chmod` the dashboard-owned shared ledger. Group access was valid, but a non-owner cannot change the file mode.

## Impact

Updates can converge the agent runtime on upgraded installations, and the broker, actuator, and worker can share the action ledger across their isolated service identities without weakening its permissions.

## Validation

- 1,985 backend tests passed, 1 skipped
- 163 browser tests passed
- full `tox -e all` commit gate passed for both commits
