### PR TITLE
Fix report scheduler provisioning on Pi updates

### DIFF
--- a/scripts/migrate_runtime_state.py
+++ b/scripts/migrate_runtime_state.py
@@ -13,7 +13,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from runtime_paths import migrate_legacy_runtime_data
-from agent_provider.provisioning import STACK_LOCK_DIR
+from agent_provider.provisioning import REPORT_SCHEDULER_STATE_DIR, STACK_LOCK_DIR
 
 
 HELPER_RESTART_DROPIN = "restart-with-pi-health.conf"
@@ -212,7 +212,7 @@ def ensure_helper_agent_permissions(
         "ReadWritePaths=/etc/apt\n"
         "ReadWritePaths=/usr /var/lib/apt /var/lib/dpkg /var/cache/apt\n"
         "ReadWritePaths=-/var/lib/lime-agent -/var/lib/limeops "
-        f"-{STACK_LOCK_DIR}\n"
+        f"-{REPORT_SCHEDULER_STATE_DIR} -{STACK_LOCK_DIR}\n"
     )
     return _ensure_helper_dropin(systemd_dir, HELPER_AGENT_DROPIN, content)
 

--- a/tests/test_migrate_runtime_state_script.py
+++ b/tests/test_migrate_runtime_state_script.py
@@ -124,6 +124,7 @@ def test_helper_agent_permissions_are_created_and_idempotent(tmp_path: Path):
     assert "/etc/passwd" not in content
     assert "ReadWritePaths=/usr /var/lib/apt /var/lib/dpkg /var/cache/apt" in content
     assert "ReadWritePaths=-/var/lib/lime-agent -/var/lib/limeops" in content
+    assert "-/var/lib/limeops-report" in content
     assert "-/opt/stacks/.locks" in content
     assert "/run/limeos" not in content
     assert "StateDirectory=" not in content


### PR DESCRIPTION
## What changed

- Add `/var/lib/limeops-report` to the privileged helper's generated `ReadWritePaths` allowlist.
- Add regression coverage for the report scheduler state path.

## Root cause

AO-007 provisions the scheduler state directory after creating the `limeops-report` system identity. The update migration did not add that directory to the helper's `ProtectSystem=strict` write allowlist, so startup convergence stopped at `install -d /var/lib/limeops-report`. This left the user and group present but did not install the scheduler runtime, unit, webhook projection, or release marker.

## Impact

After this change is merged and the Pi updates again, the migration rewrites the helper drop-in, the restart applies the new mount boundary, and startup convergence can finish installing and starting `limeops-report-scheduler.service`.

## Validation

- `tox -e all`
- 2,010 backend tests passed; 1 skipped
- 164 browser tests passed
- focused migration and provisioning tests: 74 passed