### PR TITLE
Record AO-007 target-Pi signoff

### DIFF
--- a/docs/plans/2026-07-20-agent-operations-autonomy-implementation-plan.md
+++ b/docs/plans/2026-07-20-agent-operations-autonomy-implementation-plan.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-20
 
-Status: Implementation underway; AO-007 report-only scheduler implemented 2026-07-22
+Status: Implementation underway; AO-007 completed 2026-07-23
 
 Precondition: AA-009 read-only target signoff
 
@@ -37,9 +37,10 @@ restart recovery, and one-attempt Mattermost delivery. A dedicated `limeops-repo
 can reach only the read broker, shared schedule database, and a webhook-only credential
 projection. The administrator API and Automation screen create, edit, enable, and disable
 schedules without giving the dashboard access to the broker. Local implementation and
-browser acceptance are complete; target-Pi deployment evidence remains the release signoff.
-Installation, configuration, optimisation, GitHub publication, and agent-authored pull
-requests remain later work packages.
+browser acceptance are complete. Target-Pi signoff on Holly confirmed the dedicated
+identity and sandbox, one successful Mattermost report, restart deduplication, an engaged
+action kill switch, and zero action records. Installation, configuration, optimisation,
+GitHub publication, and agent-authored pull requests remain later work packages.
 
 ## Goal
 

--- a/docs/plans/2026-07-22-agent-report-only-scheduler-design.md
+++ b/docs/plans/2026-07-22-agent-report-only-scheduler-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-22
 
-Status: Accepted implementation detail for AO-007
+Status: Accepted and target-Pi signed off 2026-07-23
 
 Parent plan: `docs/plans/2026-07-20-agent-operations-autonomy-implementation-plan.md`
 
@@ -132,3 +132,20 @@ and browser tests cover schedule creation and disablement.
 The target-Pi check keeps the action kill switch engaged, creates one short-lived
 report-only schedule, observes one delivered report and one occurrence, restarts the
 dashboard, and confirms that no duplicate report or action record appears.
+
+### Target-Pi Signoff
+
+Holly passed the release check on 2026-07-23 at commit
+`99f78242fdc6b9f5b51083227cb27d3c24c0545e`:
+
+- `limeops-report-scheduler.service` was active and enabled under the dedicated
+  `limeops-report` identity.
+- The scheduler could reach the read broker, automation database, and projected webhook.
+  The action socket, Docker socket, source checkout, and helper remained inaccessible.
+- The action kill switch stayed engaged. The short-lived schedule used one
+  `system.status` check and zero action, downtime, retry, or model-invocation budgets.
+- Occurrence `0a045ee3ecacbd9d9a10fc9cd0fc9b33` completed as `delivered` with one
+  healthy check.
+- Restarting the dashboard and scheduler left one occurrence and zero rows in both the
+  action and action-event tables.
+- The signoff schedule was disabled at revision 2 and retained as durable evidence.


### PR DESCRIPTION
## What changed

- Mark AO-007 complete in the autonomy implementation plan.
- Record Holly's deployed scheduler identity, sandbox, delivery, restart, deduplication, kill-switch, and cleanup evidence.

## Target-Pi result

Holly ran commit `99f78242fdc6b9f5b51083227cb27d3c24c0545e`. The report scheduler delivered one healthy report, retained one durable occurrence after dashboard and scheduler restarts, and created no action or action-event records. The action kill switch remained engaged throughout. The temporary schedule was disabled at revision 2.

## Validation

- Live target-Pi AO-007 acceptance on Holly
- `tox -e all`
- 2,010 backend tests passed; 1 skipped
- 164 browser tests passed
- `git diff --check`