### PR TITLE
Fix supervised repair precondition fingerprints

### DIFF
--- a/agent_actions/defaults.py
+++ b/agent_actions/defaults.py
@@ -630,6 +630,9 @@ class LazyAgentActionService:
     def propose(self, **kwargs):
         return self._get().propose(**kwargs)
 
+    def precondition(self, **kwargs):
+        return self._get().precondition(**kwargs)
+
     def approve(self, *args, **kwargs):
         return self._get().approve(*args, **kwargs)
 

--- a/agent_actions/service.py
+++ b/agent_actions/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -53,6 +53,47 @@ class AgentActionService:
         self._canary_gate = canary_gate
         self._clock = clock or (lambda: datetime.now(timezone.utc))
         self._id_factory = id_factory or (lambda: uuid.uuid4().hex)
+
+    def precondition(
+        self, *, operation: str, params: Any
+    ) -> dict[str, Any]:
+        """Return the trusted scheduled-action fingerprint without private fields."""
+
+        try:
+            capability = self._registry.require(operation)
+            normalized = capability.normalize(params)
+            target = capability.target(normalized)
+            policy = self._policy_provider()
+            policy.require_execution_enabled()
+            mode = policy.mode_for(
+                operation, target, TriggerType.SCHEDULED
+            )
+            if mode != AuthorityMode.SUPERVISED:
+                raise AgentActionError(
+                    "supervision_required",
+                    "Scheduled repairs require supervision authorization",
+                )
+            if mode not in capability.eligible_modes:
+                raise AgentActionError(
+                    "ineligible_mode",
+                    "Capability cannot use the configured authority mode",
+                )
+            before = capability.precondition(normalized)
+            if not isinstance(before, Mapping):
+                raise CapabilityError(
+                    "Capability precondition returned invalid data"
+                )
+            return {
+                "operation": operation,
+                "capability_version": capability.version,
+                "target": target,
+                "params": normalized,
+                "precondition_hash": canonical_hash(before),
+            }
+        except AgentActionError:
+            raise
+        except (CapabilityError, ActionPolicyError, ValueError) as exc:
+            raise self._public_error(exc) from exc
 
     def propose(
         self,

--- a/agent_supervision/authorization.py
+++ b/agent_supervision/authorization.py
@@ -16,6 +16,7 @@ from agent_actions.capability import (
     AuthorityMode,
     CapabilityError,
     CapabilityRegistry,
+    CapabilitySpec,
     TriggerType,
     canonical_hash,
 )
@@ -102,6 +103,9 @@ class SupervisionAuthorizer:
         policy_provider: Callable[[], ActionPolicy],
         canary_gate: CanaryGateService,
         clock: Callable[[], datetime],
+        precondition_provider: (
+            Callable[[str, Mapping[str, Any]], Mapping[str, Any]] | None
+        ) = None,
         id_factory: Callable[[], str] | None = None,
     ) -> None:
         self._store = store
@@ -110,6 +114,7 @@ class SupervisionAuthorizer:
         self._policy_provider = policy_provider
         self._canary_gate = canary_gate
         self._clock = clock
+        self._precondition_provider = precondition_provider
         self._id_factory = id_factory or (lambda: uuid.uuid4().hex)
 
     def authorize(
@@ -222,6 +227,12 @@ class SupervisionAuthorizer:
                     "evidence_ids": evidence,
                 }
             )
+            precondition_hash = self._precondition_hash(
+                capability=capability,
+                operation=schedule["operation"],
+                params=params,
+                target=target,
+            )
             action = NewAction(
                 action_id=action_id,
                 idempotency_key=occurrence_key,
@@ -238,9 +249,7 @@ class SupervisionAuthorizer:
                     f"Code-owned health assessment failed twice for {target}."
                 ),
                 impact=capability.impact(params),
-                precondition_hash=canonical_hash(
-                    capability.precondition(params)
-                ),
+                precondition_hash=precondition_hash,
                 actor_type="system",
                 actor_id="limeops-supervisor",
                 actor_username=None,
@@ -298,6 +307,55 @@ class SupervisionAuthorizer:
                 "clock_failure", "Supervision clock is unavailable"
             )
         return value.astimezone(timezone.utc)
+
+    def _precondition_hash(
+        self,
+        *,
+        capability: CapabilitySpec,
+        operation: str,
+        params: Mapping[str, Any],
+        target: str,
+    ) -> str:
+        if self._precondition_provider is None:
+            return canonical_hash(capability.precondition(params))
+        value = self._precondition_provider(operation, params)
+        if not isinstance(value, Mapping) or not value:
+            raise SupervisionAuthorizationError(
+                "precondition_unavailable",
+                "Trusted action precondition is unavailable",
+            )
+        expected_keys = {
+            "operation",
+            "capability_version",
+            "target",
+            "params",
+            "precondition_hash",
+        }
+        if (
+            set(value) != expected_keys
+            or value.get("operation") != operation
+            or value.get("capability_version") != capability.version
+            or value.get("target") != target
+            or value.get("params") != dict(params)
+        ):
+            raise SupervisionAuthorizationError(
+                "contract_changed",
+                "Trusted action precondition contract changed",
+            )
+        precondition_hash = value.get("precondition_hash")
+        if (
+            not isinstance(precondition_hash, str)
+            or len(precondition_hash) != 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in precondition_hash
+            )
+        ):
+            raise SupervisionAuthorizationError(
+                "precondition_unavailable",
+                "Trusted action precondition is unavailable",
+            )
+        return precondition_hash
 
     @staticmethod
     def _time(value: Any, label: str) -> datetime:

--- a/agent_supervision/runner.py
+++ b/agent_supervision/runner.py
@@ -87,6 +87,17 @@ def build_runtime(
         data = response.get("data") if isinstance(response, Mapping) else None
         return data if isinstance(data, Mapping) else {}
 
+    def action_precondition(
+        operation: str, params: Mapping[str, object]
+    ) -> Mapping:
+        response = diagnostic(
+            "action.precondition",
+            {"operation": operation, "params": dict(params)},
+            {"type": "system", "id": "limeops-supervisor"},
+        )
+        data = response.get("data") if isinstance(response, Mapping) else None
+        return data if isinstance(data, Mapping) else {}
+
     def unavailable(*_args):
         return {}
     registry = build_repair_registry(
@@ -115,6 +126,7 @@ def build_runtime(
         policy_provider=lambda: ActionPolicy.from_file(args.policy),
         canary_gate=canary_gate,
         clock=clock,
+        precondition_provider=action_precondition,
     )
     service = SupervisionService(store=store, clock=clock)
     return SupervisedRepairRuntime(

--- a/config/agent-policy.default.json
+++ b/config/agent-policy.default.json
@@ -88,6 +88,9 @@
     "action.propose": {
       "enabled": true
     },
+    "action.precondition": {
+      "enabled": true
+    },
     "action.approve": {
       "enabled": true
     },

--- a/docs/plans/2026-07-23-agent-supervised-repair-scheduling-design.md
+++ b/docs/plans/2026-07-23-agent-supervised-repair-scheduling-design.md
@@ -166,6 +166,13 @@ policy, canary, demotion, target lease, capability contract, precondition, and k
 switch. The supervisor never calls the action socket. Worker restart and scheduler
 restart address the existing action and occurrence instead of creating another action.
 
+The supervisor obtains the action precondition through the internal, non-model-advertised
+`action.precondition` broker read. The privileged broker calculates an opaque hash with
+the same private capability status reader used by the actuator; raw container IDs, image
+IDs, and start timestamps do not enter the public `container.status` response. The
+authorizer requires the returned operation, capability version, target, normalized
+parameters, and hash to match its current contract before it creates an action.
+
 ## Budgets, Demotion, and Recovery
 
 A successful supervised repair starts a rolling 24-hour cooldown. Another confirmed

--- a/limeops/operations.py
+++ b/limeops/operations.py
@@ -187,6 +187,17 @@ def _finding_proposal_params(params: Mapping[str, Any]) -> Mapping[str, Any]:
     return {"finding": dict(finding), "evidence_ids": list(evidence_ids)}
 
 
+def _action_precondition_params(
+    params: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    _require_fields(params, {"operation", "params"})
+    operation = _name(params, "operation")
+    action_params = params.get("params")
+    if not isinstance(action_params, Mapping):
+        raise ValueError("Parameter 'params' must be an object")
+    return {"operation": operation, "params": dict(action_params)}
+
+
 def _action_decision_params(params: Mapping[str, Any]) -> Mapping[str, Any]:
     _require_fields(params, {"action_id"})
     return {"action_id": _name(params, "action_id")}
@@ -213,6 +224,12 @@ class DiagnosticDependencies:
     installation_inventory: Callable[[], dict]
     package_status: Callable[[], dict]
     package_pending: Callable[[], dict] = lambda: {"pending": []}
+    action_precondition: Callable[[str, Mapping[str, Any]], dict] = (
+        lambda operation, params: {
+            "available": False,
+            "message": "Action precondition service is unavailable",
+        }
+    )
     action_propose: Callable[[Mapping[str, Any], Mapping[str, str], str], dict] = (
         lambda params, actor, audit_id: {
             "available": False,
@@ -256,7 +273,14 @@ def build_operations(deps: DiagnosticDependencies) -> dict[str, OperationDefinit
         return {
             "capabilities": "read-and-propose",
             "operations": sorted(
-                name for name in operations if name not in {"action.approve", "action.reject"}
+                name
+                for name in operations
+                if name
+                not in {
+                    "action.approve",
+                    "action.precondition",
+                    "action.reject",
+                }
             ),
         }
 
@@ -316,6 +340,13 @@ def build_operations(deps: DiagnosticDependencies) -> dict[str, OperationDefinit
     )
     add("packages.status", lambda p, c: deps.package_status(), _no_params)
     add("packages.pending", lambda p, c: deps.package_pending(), _no_params)
+    add(
+        "action.precondition",
+        lambda p, c: deps.action_precondition(
+            p["operation"], p["params"]
+        ),
+        _action_precondition_params,
+    )
     add(
         "action.propose",
         lambda p, c: deps.action_propose(p, c.actor, c.audit_id),

--- a/limeops/wiring.py
+++ b/limeops/wiring.py
@@ -382,6 +382,13 @@ def _action_propose(params, actor, audit_id) -> dict:  # pragma: no cover - targ
     return {"action": action, "created": created}
 
 
+def _action_precondition(operation, params) -> dict:  # pragma: no cover - target integration
+    return _ACTION_SERVICE.precondition(
+        operation=operation,
+        params=params,
+    )
+
+
 def _finding_propose(params, actor, audit_id) -> dict:  # pragma: no cover - target integration
     evidence_ids = list(params["evidence_ids"])
     if audit_id not in evidence_ids:
@@ -430,6 +437,7 @@ def default_dependencies() -> DiagnosticDependencies:  # pragma: no cover - targ
         installation_inventory=_installation_inventory,
         package_status=_package_status,
         package_pending=_package_pending,
+        action_precondition=_action_precondition,
         action_propose=_action_propose,
         finding_propose=_finding_propose,
         action_approve=_action_approve,

--- a/tests/test_agent_actions.py
+++ b/tests/test_agent_actions.py
@@ -211,6 +211,28 @@ def test_sensitive_capability_cannot_declare_automatic_authority():
         )
 
 
+def test_precondition_returns_exact_private_capability_fingerprint(tmp_path):
+    state = {"generation": 7}
+    service = _service(
+        tmp_path, state, policy=_policy(scheduled="supervised")
+    )
+
+    result = service.precondition(
+        operation="container.restart",
+        params={"name": "jellyfin"},
+    )
+
+    assert result == {
+        "operation": "container.restart",
+        "capability_version": "1",
+        "target": "jellyfin",
+        "params": {"name": "jellyfin"},
+        "precondition_hash": canonical_hash(
+            {"name": "jellyfin", "generation": 7}
+        ),
+    }
+
+
 # -- policy ------------------------------------------------------------------
 def test_policy_is_deny_by_default_per_operation_target_and_trigger():
     policy = _policy()

--- a/tests/test_agent_supervision_authorization.py
+++ b/tests/test_agent_supervision_authorization.py
@@ -18,6 +18,7 @@ from agent_actions.capability import (
     CapabilityRegistry,
     CapabilitySpec,
     RiskClass,
+    canonical_hash,
 )
 from agent_actions.ledger import (
     ActionLedger,
@@ -197,7 +198,7 @@ def _canary(ledger, registry):
     return gate
 
 
-def _setup(tmp_path, *, clock=None):
+def _setup(tmp_path, *, clock=None, precondition_provider=None):
     store = SupervisionStore(tmp_path / "supervision.sqlite3")
     schedules = SupervisionService(
         store=store,
@@ -225,6 +226,7 @@ def _setup(tmp_path, *, clock=None):
         policy_provider=_policy,
         canary_gate=gate,
         clock=clock or (lambda: NOW),
+        precondition_provider=precondition_provider,
         id_factory=lambda: "action-supervised",
     )
     return (
@@ -319,6 +321,28 @@ def test_authorization_atomically_creates_action_lease_and_budget(tmp_path):
     )
     assert budget["rolling_24h"]["used"] == 1
     assert budget["window"]["used"] == 1
+
+
+def test_authorization_uses_trusted_precondition_instead_of_public_status(
+    tmp_path,
+):
+    trusted_hash = "f" * 64
+    authorizer, _schedules, ledger, incident_id, _registry, _gate = _setup(
+        tmp_path,
+        precondition_provider=lambda operation, params: {
+            "operation": operation,
+            "capability_version": "1",
+            "target": params["name"],
+            "params": dict(params),
+            "precondition_hash": trusted_hash,
+        },
+    )
+
+    result, created = authorizer.authorize("schedule-1", incident_id)
+
+    assert created is True
+    assert result["action"]["id"] == "action-supervised"
+    assert ledger.get("action-supervised").precondition_hash == trusted_hash
 
 
 def test_authorization_occurrence_replay_does_not_duplicate_charge(tmp_path):
@@ -553,6 +577,72 @@ def test_actuator_independently_accepts_bound_authorization(tmp_path):
     assert completed["approval_consumed"] is False
     assert calls == [{"name": "get_iplayer"}]
     assert ledger.has_supervised_execution_slot(result["action"]["id"]) is False
+
+
+def test_trusted_fingerprint_matches_actuator_private_status_reader(tmp_path):
+    private_before = {
+        "name": "get_iplayer",
+        "id": "container-id",
+        "status": "exited",
+        "health": "",
+        "started_at": "2026-07-23T09:00:00Z",
+        "image_id": "sha256:image-id",
+    }
+    trusted_hash = canonical_hash(private_before)
+    authorizer, _schedules, ledger, incident_id, _registry, gate = _setup(
+        tmp_path,
+        precondition_provider=lambda operation, params: {
+            "operation": operation,
+            "capability_version": "1",
+            "target": params["name"],
+            "params": dict(params),
+            "precondition_hash": trusted_hash,
+        },
+    )
+    result, _ = authorizer.authorize("schedule-1", incident_id)
+    base = _capability()
+    actuator_registry = CapabilityRegistry(
+        [
+            CapabilitySpec(
+                operation=base.operation,
+                version=base.version,
+                risk=base.risk,
+                eligible_modes=base.eligible_modes,
+                normalize_params=base.normalize_params,
+                select_target=base.select_target,
+                read_precondition=lambda _params: private_before,
+                render_impact=base.render_impact,
+            )
+        ]
+    )
+    calls = []
+    actuator = ActionActuator(
+        registry=actuator_registry,
+        executors={
+            "container.restart": ExecutionSpec(
+                operation="container.restart",
+                version="1",
+                execute=lambda params: calls.append(dict(params))
+                or {"status": "restarted"},
+                verify=lambda _params, _before: (
+                    True,
+                    {"status": "running"},
+                ),
+                no_rollback_reason="No safe rollback",
+            )
+        },
+        policy_provider=_policy,
+        ledger=ledger,
+        canary_gate=gate,
+        clock=lambda: NOW + timedelta(seconds=30),
+    )
+
+    completed = actuator.execute(
+        result["action"]["id"], audit_id="audit-private-fingerprint"
+    )
+
+    assert completed["state"] == "succeeded"
+    assert calls == [{"name": "get_iplayer"}]
 
 
 def test_disablement_atomically_cancels_queued_supervised_action(tmp_path):

--- a/tests/test_agent_supervision_runner.py
+++ b/tests/test_agent_supervision_runner.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from agent_supervision.runner import build_runtime
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, operation, params, actor):
+        self.calls.append((operation, params, actor))
+        return {
+            "ok": True,
+            "data": {
+                "operation": "container.restart",
+                "capability_version": "1",
+                "target": "get_iplayer",
+                "params": {"name": "get_iplayer"},
+                "precondition_hash": "a" * 64,
+            },
+        }
+
+
+def test_runtime_reads_trusted_action_precondition_through_broker(tmp_path):
+    client = RecordingClient()
+    args = SimpleNamespace(
+        supervision=str(tmp_path / "supervision.sqlite3"),
+        ledger=str(tmp_path / "actions.sqlite3"),
+        socket=str(tmp_path / "limeops.sock"),
+        policy=str(tmp_path / "action-policy.json"),
+        delivery_config=str(tmp_path / "delivery.json"),
+        delivery_secrets=str(tmp_path / "mattermost.env"),
+    )
+    runtime = build_runtime(
+        args,
+        scheduler=object(),
+        client=client,
+        delivery=lambda _context: "post-1",
+    )
+
+    result = runtime._authorizer._precondition_provider(
+        "container.restart", {"name": "get_iplayer"}
+    )
+
+    assert result["precondition_hash"] == "a" * 64
+    assert client.calls == [
+        (
+            "action.precondition",
+            {
+                "operation": "container.restart",
+                "params": {"name": "get_iplayer"},
+            },
+            {"type": "system", "id": "limeops-supervisor"},
+        )
+    ]

--- a/tests/test_limeops_operations.py
+++ b/tests/test_limeops_operations.py
@@ -47,6 +47,13 @@ def make_deps(**overrides):
         "network_check": lambda target: {"target": target, "ok": True},
         "installation_inventory": lambda: {"units": {}},
         "package_status": lambda: {"ok": True, "drift": [], "packages": []},
+        "action_precondition": lambda operation, params: {
+            "operation": operation,
+            "capability_version": "1",
+            "target": params["name"],
+            "params": dict(params),
+            "precondition_hash": "a" * 64,
+        },
     }
     values.update(overrides)
     return DiagnosticDependencies(**values)
@@ -178,7 +185,11 @@ def test_gateway_allowlist_matches_the_shipped_read_only_policy():
     with open("config/agent-policy.default.json") as handle:
         policy_operations = set(json.load(handle)["operations"])
     model_operations = set(GatewayConfig().allowed_operations)
-    assert policy_operations - model_operations == {"action.approve", "action.reject"}
+    assert policy_operations - model_operations == {
+        "action.approve",
+        "action.precondition",
+        "action.reject",
+    }
     assert model_operations < policy_operations
     assert set(build_operations(make_deps())) == policy_operations
 
@@ -188,6 +199,7 @@ def test_context_reports_read_and_propose_capabilities_and_operations():
     data = operations["context"].handler({}, None)
     assert data["capabilities"] == "read-and-propose"
     assert "container.logs" in data["operations"]
+    assert "action.precondition" not in data["operations"]
 
 
 # -- through the real broker ---------------------------------------------------------
@@ -248,6 +260,65 @@ def test_action_propose_forwards_actor_and_current_audit_as_evidence():
     assert params["evidence_ids"] == ["earlier-audit"]
     assert actor == ACTOR
     assert audit_id == response["audit_id"]
+
+
+def test_action_precondition_returns_only_the_trusted_hash_contract():
+    calls = []
+
+    def precondition(operation, params):
+        calls.append((operation, params))
+        return {
+            "operation": operation,
+            "capability_version": "1",
+            "target": params["name"],
+            "params": dict(params),
+            "precondition_hash": "b" * 64,
+        }
+
+    broker = make_broker(
+        build_operations(make_deps(action_precondition=precondition))
+    )
+    response = call(
+        broker,
+        "action.precondition",
+        {
+            "operation": "container.restart",
+            "params": {"name": "jellyfin"},
+        },
+    )
+
+    assert response["ok"] is True
+    assert response["data"]["precondition_hash"] == "b" * 64
+    assert calls == [
+        ("container.restart", {"name": "jellyfin"})
+    ]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"operation": "container.restart", "params": []},
+        {"operation": "", "params": {"name": "jellyfin"}},
+        {
+            "operation": "container.restart",
+            "params": {"name": "jellyfin"},
+            "precondition_hash": "forged",
+        },
+    ],
+)
+def test_action_precondition_rejects_malformed_or_forged_fields(params):
+    calls = []
+    broker = make_broker(
+        build_operations(
+            make_deps(action_precondition=lambda *args: calls.append(args))
+        )
+    )
+
+    response = call(broker, "action.precondition", params)
+
+    assert response["ok"] is False
+    assert response["error"]["code"] == "invalid_input"
+    assert calls == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a non-model-advertised, hash-only action precondition broker read
- make supervised authorization use the actuator's trusted private capability fingerprint
- retain public container status redaction and validate the exact returned contract
- migrate existing broker policies during the normal agent update path
- document and regression-test the production status-shape mismatch

## Verification
- tox -e all
- 2,150 backend tests passed, 1 skipped
- 165 browser tests passed
- Holly canary evidence retained; service recovered; schedule disabled; policy restored; canary revoked

## Live follow-up
After merge and Holly update, repeat the final repair execution canary after the existing 24-hour disruption cooldown expires.