### PR TITLE
Keep retained supervision schedules visible under restrictive policy

### DIFF
--- a/agent_supervision/admin.py
+++ b/agent_supervision/admin.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from agent_actions.capability import TriggerType
+from agent_actions.capability import AuthorityMode, TriggerType
 from agent_actions.defaults import read_agent_release_commit
 from agent_actions.ledger import ActionLedger, ActionLedgerError
 from agent_actions.policy import ActionPolicy, ActionPolicyError
@@ -351,6 +351,8 @@ class SupervisionAdminService:
                 TriggerType.SCHEDULED,
             ).value
         except ActionPolicyError as exc:
+            if exc.code in {"denied_operation", "denied_target"}:
+                return AuthorityMode.OBSERVE.value
             raise SupervisionAdminError(exc.code, str(exc)) from exc
 
     def _action(self, action_id: str | None) -> dict[str, Any] | None:

--- a/tests/test_agent_supervision_admin.py
+++ b/tests/test_agent_supervision_admin.py
@@ -140,6 +140,57 @@ def test_admin_schedule_projection_exposes_read_only_safety_state(tmp_path):
     assert listed["schedules"][0]["id"] == "schedule-1"
 
 
+@pytest.mark.parametrize(
+    "operation_policy",
+    [
+        {"enabled": False, "approvers": [], "targets": {}},
+        {"enabled": True, "approvers": [], "targets": {}},
+    ],
+)
+def test_admin_keeps_retained_schedule_visible_when_policy_denies_it(
+    tmp_path, operation_policy
+):
+    admin = _admin(tmp_path)
+    admin.create(
+        _schedule(),
+        owner={"type": "local", "id": "admin", "username": "admin"},
+    )
+    (tmp_path / "policy.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "kill_switch": True,
+                "defaults": {"proposal_ttl_seconds": 900},
+                "operations": {
+                    "container.restart": operation_policy,
+                },
+            }
+        )
+    )
+
+    projected = admin.get("schedule-1")
+    listed = admin.list()["schedules"][0]
+
+    assert projected["enabled"] is False
+    assert projected["status"]["configured_authority"] == "observe"
+    assert projected["status"]["effective_authority"] == "observe"
+    assert listed == projected
+
+
+def test_admin_still_fails_closed_for_malformed_policy(tmp_path):
+    admin = _admin(tmp_path)
+    admin.create(
+        _schedule(),
+        owner={"type": "local", "id": "admin", "username": "admin"},
+    )
+    (tmp_path / "policy.json").write_text("{}")
+
+    with pytest.raises(SupervisionAdminError) as invalid:
+        admin.get("schedule-1")
+
+    assert invalid.value.code == "invalid_policy"
+
+
 def test_admin_incident_detail_keeps_bounded_assessment_and_transition_history(
     tmp_path,
 ):


### PR DESCRIPTION
## What changed

- Treat expected `denied_operation` and `denied_target` policy states as an observe-only authority projection.
- Keep retained disabled supervision schedules available through admin list and detail views after the original restrictive policy is restored.
- Continue to fail closed for malformed or unreadable policy data.

## Root cause

The admin projection recalculated configured authority using the current action policy. Restoring the pre-canary policy intentionally disabled `container.restart`, causing expected policy denials to become fatal API errors and hiding retained schedule/evidence records.

## Impact

Historical and disabled repair schedules remain reviewable without granting any repair authority. A denied capability is projected as `observe`; invalid policy remains an error.

## Validation

- `tox -e all`
- Backend: 2,153 passed, 1 skipped, 165 deselected
- Browser: 165 passed
- Lint and committed web bundle freshness passed
