### PR TITLE
Allow the action actuator to recheck AI Agents lifecycle state

### DIFF
--- a/agent_provider/provisioning.py
+++ b/agent_provider/provisioning.py
@@ -180,7 +180,7 @@ LockPersonality=true
 RestrictAddressFamilies=AF_UNIX
 ReadOnlyPaths={AGENT_LIB_DIR} {ACTION_POLICY_PATH} {ACTION_BROKER_POLICY_PATH}
 ReadWritePaths={ACTION_SOCKET_DIR} {ACTION_STATE_DIR} /var/log/limeos {STACK_LOCK_DIR}
-InaccessiblePaths=/root {repo_dir} /run/pihealth /etc/limeos/credentials.env
+InaccessiblePaths=/root {repo_dir} /etc/limeos/credentials.env
 CapabilityBoundingSet=
 
 [Install]

--- a/tests/test_agent_provisioning.py
+++ b/tests/test_agent_provisioning.py
@@ -124,6 +124,14 @@ def test_action_units_keep_worker_unprivileged_and_socket_separate():
     assert "SupplementaryGroups=docker" not in worker
     assert "limeops-client" not in broker
     assert "limeops-client" not in worker
+    broker_inaccessible = next(
+        line for line in broker.splitlines() if line.startswith("InaccessiblePaths=")
+    )
+    worker_inaccessible = next(
+        line for line in worker.splitlines() if line.startswith("InaccessiblePaths=")
+    )
+    assert "/run/pihealth" not in broker_inaccessible
+    assert "/run/pihealth" in worker_inaccessible
 
 
 def test_report_scheduler_unit_has_read_broker_and_report_state_only():


### PR DESCRIPTION
## What changed

- Remove `/run/pihealth` from only the action actuator's `InaccessiblePaths` sandbox list.
- Keep the queue worker blocked from the privileged helper socket.
- Add a provisioning regression that freezes this separation.

## Root cause

Holly's final AO-009 canary reached two failed health assessments and created one supervised action, but the actuator cancelled it with `integration_disabled`. The actuator is required to call `agent_supervision_enabled` through `/run/pihealth/helper.sock`, while its own systemd unit made `/run/pihealth` inaccessible. The request therefore never reached the helper and the lifecycle check failed closed.

## Impact

Supervised actions can now perform their independent execution-time lifecycle check. Access remains bounded by the actuator's `pihealth` supplementary group and the helper's fixed command allowlist; the unprivileged worker remains unable to reach the helper.

## Holly evidence and rollback

- Action `f74065181898456c814db44b96e7f8a1` was safely cancelled before mutation with `integration_disabled`.
- The schedule was disabled at revision 6.
- The temporary current-release canary was revoked.
- The original kill-switch policy was restored byte-for-byte (`afce77a…444d8`).
- `get_iplayer` was manually restored and is running.
- The budget charge is retained and prevents another attempt until 27 July at 17:30 BST.

## Validation

- Focused provisioning and supervision tests: 83 passed
- `tox -e all`
- Backend: 2,311 passed, 1 skipped, 165 deselected
- Browser: 165 passed
- Lint and committed web-bundle freshness passed
